### PR TITLE
Fix thread id bug in voice handler

### DIFF
--- a/main.py
+++ b/main.py
@@ -257,6 +257,7 @@ def handle_voiceoff_command(message, bot_instance):
 
 def handle_voice_message(message, bot_instance):
     chat_id = message["chat"]["id"]
+    thread_id = message.get("message_thread_id")
     set_audio_mode_whisper(chat_id)
     file_id = message["voice"]["file_id"]
     file_path = bot_instance.get_file_path(file_id)


### PR DESCRIPTION
## Summary
- reference `message_thread_id` in `handle_voice_message` so voice replies do not crash

## Testing
- `python -m py_compile main.py utils/*.py`

------
https://chatgpt.com/codex/tasks/task_e_686efee7e2e08329846a40d893c50c79