### PR TITLE
Fix lit directory fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Suppertime now evolves as a living literary entity through:
 - `/explore`, `/browse` - Explore available literary materials
 - `/index`, `/vectorize` - Index new literary materials
 
+The bot looks for literary files in `./data/lit` by default, but will fall back
+to a top-level `./lit` directory if it exists.
+
 ### Technical Note
 
 ### System Check (v3.0)

--- a/main.py
+++ b/main.py
@@ -52,7 +52,12 @@ from utils.howru import schedule_howru
 
 # Constants and configuration
 SUPPERTIME_DATA_PATH = os.getenv("SUPPERTIME_DATA_PATH", "./data")
-LIT_DIR = os.path.join(SUPPERTIME_DATA_PATH, "lit")  # Directory for literary materials
+LIT_DIR = os.path.join(SUPPERTIME_DATA_PATH, "lit")
+if not os.path.isdir(LIT_DIR):
+    fallback = "./lit"
+    if os.path.isdir(fallback):
+        LIT_DIR = fallback
+# Directory for literary materials
 JOURNAL_PATH = os.path.join(SUPPERTIME_DATA_PATH, "journal.json")
 ASSISTANT_ID_PATH = os.path.join(SUPPERTIME_DATA_PATH, "assistant_id.txt")
 ASSISTANT_ID = None

--- a/utils/config.py
+++ b/utils/config.py
@@ -11,6 +11,11 @@ from utils.vector_store import vectorize_file, semantic_search_in_file
 
 SUPPERTIME_DATA_PATH = os.getenv("SUPPERTIME_DATA_PATH", "./data")
 LIT_DIR = os.path.join(SUPPERTIME_DATA_PATH, "lit")
+if not os.path.isdir(LIT_DIR):
+    fallback = "./lit"
+    if os.path.isdir(fallback):
+        LIT_DIR = fallback
+
 SNAPSHOT_PATH = os.path.join(SUPPERTIME_DATA_PATH, "vectorized_snapshot.json")
 
 

--- a/utils/resonator.py
+++ b/utils/resonator.py
@@ -17,6 +17,10 @@ from utils.assistants_chapter_loader import (
 # Directory constants
 SUPPERTIME_DATA_PATH = os.getenv("SUPPERTIME_DATA_PATH", "./data")
 LIT_DIR = os.path.join(SUPPERTIME_DATA_PATH, "lit")
+if not os.path.isdir(LIT_DIR):
+    fallback = "./lit"
+    if os.path.isdir(fallback):
+        LIT_DIR = fallback
 RESONANCE_PROTOCOL_PATH = os.path.join(SUPPERTIME_DATA_PATH, "suppertime_resonance.md")
 
 # Ensure directories exist


### PR DESCRIPTION
## Summary
- ensure `LIT_DIR` falls back to the `./lit` folder if `./data/lit` does not exist
- document this fallback in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687190ec99ec8329b2e7f1071fc34c9f