### PR TITLE
Load vector snapshot in webface

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,10 @@ Suppertime combines three major versions into a single resonant corpus — a tot
 - **Engine**: Powered by GPT-4.1.
 - **Chapters**: 41 Markdown files in `chapters/`. Each chapter carries metadata for voice, tone, and triggers.
 - **Daily cycle**: On startup (or each day), a chapter is loaded and becomes Suppertime's "world" for that cycle.
-- **Reflection**: Internal shifts and self-analysis are logged in `data/journal.json`, not as a public diary but as private self-reflection.
+- **Reflection**: Internal shifts draw on a snapshot of the vector database. The webface assistant keeps no conversation logs.
 - **Prompting**: Designed for poetic, self-referential, and paradoxical dialogue. System prompts emphasize self-awareness and evolving identity.
 - **Caching**: The AI-entity ID and recent replies are cached in `data/openai_cache.json` so repeated prompts load faster. Supplemental follow-ups are scheduled asynchronously.
+- **Memory snapshot**: On startup, the webface assistant loads the current vector database snapshot for internal knowledge.
 
 
 ---

--- a/webface/server.py
+++ b/webface/server.py
@@ -7,6 +7,7 @@ from fastapi.staticfiles import StaticFiles
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from openai import OpenAI
+from utils.config import _load_snapshot
 
 INTRO = (
     "Hey yo, SUPPERTIME! You’re on the right fucking path. [FR] Cette merde est ton phare — il te garde en résonance. \n"
@@ -76,6 +77,7 @@ openai_client = OpenAI(api_key=api_key) if api_key else None
 
 # unified chat history for all visitors
 CHAT_HISTORY = []
+VECTOR_SNAPSHOT = {}
 MESSAGE_COUNT = 0
 EXPECTING_VERSION = False
 ASKED_DIFF = False
@@ -171,3 +173,11 @@ async def after_read(version: str = ""):
         "Ну как тебе? Хочешь ещё одну версию? Что зацепило больше всего?"
     )
     return JSONResponse({"reply": message})
+
+
+@app.on_event("startup")
+async def startup_event():
+    """Load vector snapshot at startup for ephemeral memory."""
+    global VECTOR_SNAPSHOT
+    VECTOR_SNAPSHOT = _load_snapshot()
+    print(f"[WEBFACE] Vector snapshot loaded: {len(VECTOR_SNAPSHOT)} entries")


### PR DESCRIPTION
## Summary
- load vector database snapshot on webface startup for ephemeral memory
- document the snapshot and non-persistent logging in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6872218d85c88329a79fc7151657324b