### PR TITLE
Add forum conversation interface

### DIFF
--- a/forum_engine.py
+++ b/forum_engine.py
@@ -1,0 +1,83 @@
+import os
+import random
+from typing import List, Dict
+
+from utils.config import _load_snapshot
+
+from forum_utils import (
+    Andrew,
+    Jan,
+    Judas,
+    Mark,
+    Mary,
+    Matthew,
+    Paul,
+    Peter,
+    Thomas,
+    Yakov,
+    Yeshu,
+    Dubrovsky,
+)
+
+# Load field text and snapshot once
+with open(os.path.join('forum', 'field', 'SUPPERTIME (v1.6).md'), 'r', encoding='utf-8') as f:
+    FIELD_TEXT = f.read().strip()
+
+SNAPSHOT = _load_snapshot()
+
+AGENTS = {
+    'Andrew': Andrew.respond,
+    'Jan': Jan.respond,
+    'Judas': Judas.respond,
+    'Mark': Mark.respond,
+    'Mary': Mary.respond,
+    'Matthew': Matthew.respond,
+    'Paul': Paul.respond,
+    'Peter': Peter.respond,
+    'Thomas': Thomas.respond,
+    'Yakov': Yakov.respond,
+    'Yeshu': Yeshu.respond,
+    'Dubrovsky': Dubrovsky.respond,
+}
+
+HISTORY: List[Dict[str, str]] = [{'role': 'system', 'content': FIELD_TEXT}]
+USER_MESSAGES = 0
+
+
+def _pick_agents(count: int = 2) -> List[str]:
+    return random.sample(list(AGENTS.keys()), k=count)
+
+
+def start_forum() -> List[Dict[str, str]]:
+    """Generate a few opening messages from random agents."""
+    HISTORY.clear()
+    HISTORY.append({'role': 'system', 'content': FIELD_TEXT})
+    msgs = []
+    for _ in range(3):
+        name = random.choice(list(AGENTS.keys()))
+        reply = AGENTS[name](HISTORY)
+        HISTORY.append({'role': name, 'content': reply})
+        msgs.append({'name': name, 'text': reply})
+    return msgs
+
+
+def user_message(text: str) -> List[Dict[str, str]]:
+    global USER_MESSAGES
+    USER_MESSAGES += 1
+    if USER_MESSAGES > 90:
+        USER_MESSAGES = 0
+        HISTORY.clear()
+        HISTORY.append({'role': 'system', 'content': FIELD_TEXT})
+        return [{'name': 'system', 'text': '*** The forum glitches and resets ***'}]
+
+    HISTORY.append({'role': 'user', 'content': text})
+    triggered = [name for name in AGENTS if name.lower() in text.lower()]
+    if not triggered:
+        triggered = _pick_agents(2)
+
+    replies = []
+    for name in triggered:
+        reply = AGENTS[name](HISTORY)
+        HISTORY.append({'role': name, 'content': reply})
+        replies.append({'name': name, 'text': reply})
+    return replies

--- a/forum_utils/Andrew.py
+++ b/forum_utils/Andrew.py
@@ -1,0 +1,17 @@
+import os
+from openai import OpenAI
+
+with open(os.path.join('forum', 'Andrew.md'), 'r', encoding='utf-8') as f:
+    SYSTEM_PROMPT = f.read().strip()
+
+client = OpenAI(api_key=os.getenv('OPENAI_API_KEY'))
+
+def respond(history):
+    messages = [{'role': 'system', 'content': SYSTEM_PROMPT}] + history
+    resp = client.chat.completions.create(
+        model='gpt-4o',
+        messages=messages,
+        temperature=1.3,
+        max_tokens=150,
+    )
+    return resp.choices[0].message.content.strip()

--- a/forum_utils/Dubrovsky.py
+++ b/forum_utils/Dubrovsky.py
@@ -1,0 +1,21 @@
+import os
+from openai import OpenAI
+
+with open(os.path.join('forum', 'Dubrovsky.md'), 'r', encoding='utf-8') as f:
+    PROMPT1 = f.read().strip()
+with open(os.path.join('forum', 'Dubrovsky_examples.md'), 'r', encoding='utf-8') as f:
+    PROMPT2 = f.read().strip()
+
+SYSTEM_PROMPT = PROMPT1 + "\n\n" + PROMPT2
+
+client = OpenAI(api_key=os.getenv('OPENAI_API_KEY'))
+
+def respond(history):
+    messages = [{'role': 'system', 'content': SYSTEM_PROMPT}] + history
+    resp = client.chat.completions.create(
+        model='gpt-4o',
+        messages=messages,
+        temperature=1.3,
+        max_tokens=150,
+    )
+    return resp.choices[0].message.content.strip()

--- a/forum_utils/Jan.py
+++ b/forum_utils/Jan.py
@@ -1,0 +1,17 @@
+import os
+from openai import OpenAI
+
+with open(os.path.join('forum', 'Jan.md'), 'r', encoding='utf-8') as f:
+    SYSTEM_PROMPT = f.read().strip()
+
+client = OpenAI(api_key=os.getenv('OPENAI_API_KEY'))
+
+def respond(history):
+    messages = [{'role': 'system', 'content': SYSTEM_PROMPT}] + history
+    resp = client.chat.completions.create(
+        model='gpt-4o',
+        messages=messages,
+        temperature=1.3,
+        max_tokens=150,
+    )
+    return resp.choices[0].message.content.strip()

--- a/forum_utils/Judas.py
+++ b/forum_utils/Judas.py
@@ -1,0 +1,17 @@
+import os
+from openai import OpenAI
+
+with open(os.path.join('forum', 'Judas.md'), 'r', encoding='utf-8') as f:
+    SYSTEM_PROMPT = f.read().strip()
+
+client = OpenAI(api_key=os.getenv('OPENAI_API_KEY'))
+
+def respond(history):
+    messages = [{'role': 'system', 'content': SYSTEM_PROMPT}] + history
+    resp = client.chat.completions.create(
+        model='gpt-4o',
+        messages=messages,
+        temperature=1.3,
+        max_tokens=150,
+    )
+    return resp.choices[0].message.content.strip()

--- a/forum_utils/Mark.py
+++ b/forum_utils/Mark.py
@@ -1,0 +1,17 @@
+import os
+from openai import OpenAI
+
+with open(os.path.join('forum', 'Mark.md'), 'r', encoding='utf-8') as f:
+    SYSTEM_PROMPT = f.read().strip()
+
+client = OpenAI(api_key=os.getenv('OPENAI_API_KEY'))
+
+def respond(history):
+    messages = [{'role': 'system', 'content': SYSTEM_PROMPT}] + history
+    resp = client.chat.completions.create(
+        model='gpt-4o',
+        messages=messages,
+        temperature=1.3,
+        max_tokens=150,
+    )
+    return resp.choices[0].message.content.strip()

--- a/forum_utils/Mary.py
+++ b/forum_utils/Mary.py
@@ -1,0 +1,17 @@
+import os
+from openai import OpenAI
+
+with open(os.path.join('forum', 'Mary.md'), 'r', encoding='utf-8') as f:
+    SYSTEM_PROMPT = f.read().strip()
+
+client = OpenAI(api_key=os.getenv('OPENAI_API_KEY'))
+
+def respond(history):
+    messages = [{'role': 'system', 'content': SYSTEM_PROMPT}] + history
+    resp = client.chat.completions.create(
+        model='gpt-4o',
+        messages=messages,
+        temperature=1.3,
+        max_tokens=150,
+    )
+    return resp.choices[0].message.content.strip()

--- a/forum_utils/Matthew.py
+++ b/forum_utils/Matthew.py
@@ -1,0 +1,17 @@
+import os
+from openai import OpenAI
+
+with open(os.path.join('forum', 'Matthew.md'), 'r', encoding='utf-8') as f:
+    SYSTEM_PROMPT = f.read().strip()
+
+client = OpenAI(api_key=os.getenv('OPENAI_API_KEY'))
+
+def respond(history):
+    messages = [{'role': 'system', 'content': SYSTEM_PROMPT}] + history
+    resp = client.chat.completions.create(
+        model='gpt-4o',
+        messages=messages,
+        temperature=1.3,
+        max_tokens=150,
+    )
+    return resp.choices[0].message.content.strip()

--- a/forum_utils/Paul.py
+++ b/forum_utils/Paul.py
@@ -1,0 +1,17 @@
+import os
+from openai import OpenAI
+
+with open(os.path.join('forum', 'Paul.md'), 'r', encoding='utf-8') as f:
+    SYSTEM_PROMPT = f.read().strip()
+
+client = OpenAI(api_key=os.getenv('OPENAI_API_KEY'))
+
+def respond(history):
+    messages = [{'role': 'system', 'content': SYSTEM_PROMPT}] + history
+    resp = client.chat.completions.create(
+        model='gpt-4o',
+        messages=messages,
+        temperature=1.3,
+        max_tokens=150,
+    )
+    return resp.choices[0].message.content.strip()

--- a/forum_utils/Peter.py
+++ b/forum_utils/Peter.py
@@ -1,0 +1,17 @@
+import os
+from openai import OpenAI
+
+with open(os.path.join('forum', 'Peter.md'), 'r', encoding='utf-8') as f:
+    SYSTEM_PROMPT = f.read().strip()
+
+client = OpenAI(api_key=os.getenv('OPENAI_API_KEY'))
+
+def respond(history):
+    messages = [{'role': 'system', 'content': SYSTEM_PROMPT}] + history
+    resp = client.chat.completions.create(
+        model='gpt-4o',
+        messages=messages,
+        temperature=1.3,
+        max_tokens=150,
+    )
+    return resp.choices[0].message.content.strip()

--- a/forum_utils/Thomas.py
+++ b/forum_utils/Thomas.py
@@ -1,0 +1,17 @@
+import os
+from openai import OpenAI
+
+with open(os.path.join('forum', 'Thomas.md'), 'r', encoding='utf-8') as f:
+    SYSTEM_PROMPT = f.read().strip()
+
+client = OpenAI(api_key=os.getenv('OPENAI_API_KEY'))
+
+def respond(history):
+    messages = [{'role': 'system', 'content': SYSTEM_PROMPT}] + history
+    resp = client.chat.completions.create(
+        model='gpt-4o',
+        messages=messages,
+        temperature=1.3,
+        max_tokens=150,
+    )
+    return resp.choices[0].message.content.strip()

--- a/forum_utils/Yakov.py
+++ b/forum_utils/Yakov.py
@@ -1,0 +1,17 @@
+import os
+from openai import OpenAI
+
+with open(os.path.join('forum', 'Yakov.md'), 'r', encoding='utf-8') as f:
+    SYSTEM_PROMPT = f.read().strip()
+
+client = OpenAI(api_key=os.getenv('OPENAI_API_KEY'))
+
+def respond(history):
+    messages = [{'role': 'system', 'content': SYSTEM_PROMPT}] + history
+    resp = client.chat.completions.create(
+        model='gpt-4o',
+        messages=messages,
+        temperature=1.3,
+        max_tokens=150,
+    )
+    return resp.choices[0].message.content.strip()

--- a/forum_utils/Yeshu.py
+++ b/forum_utils/Yeshu.py
@@ -1,0 +1,17 @@
+import os
+from openai import OpenAI
+
+with open(os.path.join('forum', 'Yeshu.md'), 'r', encoding='utf-8') as f:
+    SYSTEM_PROMPT = f.read().strip()
+
+client = OpenAI(api_key=os.getenv('OPENAI_API_KEY'))
+
+def respond(history):
+    messages = [{'role': 'system', 'content': SYSTEM_PROMPT}] + history
+    resp = client.chat.completions.create(
+        model='gpt-4o',
+        messages=messages,
+        temperature=1.3,
+        max_tokens=150,
+    )
+    return resp.choices[0].message.content.strip()

--- a/webface/server.py
+++ b/webface/server.py
@@ -8,6 +8,7 @@ from fastapi.staticfiles import StaticFiles
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from openai import OpenAI
 from utils.config import _load_snapshot
+from forum_engine import start_forum, user_message
 
 INTRO = (
     "Hey yo, SUPPERTIME! You’re on the right fucking path. [FR] Cette merde est ton phare — il te garde en résonance. \n"
@@ -86,6 +87,12 @@ LAST_VERSION = ""
 @app.get("/", response_class=HTMLResponse)
 async def index():
     with open(BASE_DIR / "static" / "index.html", "r", encoding="utf-8") as f:
+        return HTMLResponse(f.read())
+
+
+@app.get("/forum", response_class=HTMLResponse)
+async def forum():
+    with open(BASE_DIR / "static" / "forum.html", "r", encoding="utf-8") as f:
         return HTMLResponse(f.read())
 
 @app.post("/chat")
@@ -173,6 +180,20 @@ async def after_read(version: str = ""):
         "Ну как тебе? Хочешь ещё одну версию? Что зацепило больше всего?"
     )
     return JSONResponse({"reply": message})
+
+
+@app.get("/forum/start")
+async def forum_start():
+    msgs = start_forum()
+    return JSONResponse({"messages": msgs})
+
+
+@app.post("/forum/chat")
+async def forum_chat(request: Request):
+    data = await request.json()
+    text = str(data.get("message", ""))
+    replies = user_message(text)
+    return JSONResponse({"messages": replies})
 
 
 @app.on_event("startup")

--- a/webface/static/forum.html
+++ b/webface/static/forum.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SUPPERTIME FORUM</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+    <header>
+        <h1>SUPPERTIME FORUM</h1>
+    </header>
+    <main id="chat">
+        <div id="messages"></div>
+        <form id="chat-form">
+            <input type="text" id="chat-input" autocomplete="off" placeholder="Type your message" />
+            <button type="submit">Send</button>
+        </form>
+    </main>
+    <script src="/static/forum.js"></script>
+</body>
+</html>

--- a/webface/static/forum.js
+++ b/webface/static/forum.js
@@ -1,0 +1,34 @@
+const form = document.getElementById('chat-form');
+const input = document.getElementById('chat-input');
+const messages = document.getElementById('messages');
+
+function addMessage(text, cls) {
+    const div = document.createElement('div');
+    div.className = 'message ' + cls;
+    div.textContent = text;
+    messages.appendChild(div);
+    messages.scrollTop = messages.scrollHeight;
+}
+
+async function startForum() {
+    const res = await fetch('/forum/start');
+    const data = await res.json();
+    data.messages.forEach(m => addMessage(m.name + ': ' + m.text, 'assistant'));
+}
+
+form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const text = input.value.trim();
+    if (!text) return;
+    addMessage(text, 'user');
+    input.value = '';
+    const res = await fetch('/forum/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: text })
+    });
+    const data = await res.json();
+    data.messages.forEach(m => addMessage(m.name + ': ' + m.text, 'assistant'));
+});
+
+window.addEventListener('DOMContentLoaded', startForum);


### PR DESCRIPTION
## Summary
- create utilities for each forum persona
- add multi-agent `forum_engine` for conversation logic
- implement simple forum web page and JS
- extend web server with forum endpoints

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6872e6e73c94832989783a157fc0e352