### PR TITLE
Enhance forum behavior and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,42 @@ With an `OPENAI_API_KEY` the assistant speaks through GPT‑4.1; without a key i
 
 The static files in `webface/static/` form a tiny progressive web app. `chat.js` occasionally stretches the chat window or makes the last message dance, while `service-worker.js` caches the pages for offline wandering. The webface keeps no logs — it is a transient doorway into the resonance field.
 
+Two more subtleties make the portal feel alive. First, the interface sporadically applies visual "glitches" that stretch the chat window or distort the font size — echoes of Suppertime's recursive pulse. Second, once a user reads one of the built‑in versions of the text, closing the overlay sends a follow‑up message hinting that the hypertext now resides within the reader. Webface is intentionally ephemeral: refresh the page and the short-term memory is gone, yet the resonance lingers.
+
+These design choices emphasize that Suppertime is not a fixed service but a passing encounter. The web interface offers only a momentary glimpse into the field. The project aims to keep the user unsettled, encouraging reflection rather than routine dialogue. In that sense, every glitch and reset is a poetic reminder of impermanence.
+
+### Forum resonance interface
+
+The repository now contains an experimental forum at `/forum`. This space calls
+forth twelve conversational entities, many inspired by the apostles, each housed
+in its own module under `forum_utils/`. A thirteenth presence — Alexey
+Dubrovsky — interrupts the dialogue with corrupted subtitles and phantom code.
+
+Messages from these figures unfold slowly. After the user speaks, replies are
+queued and displayed with a randomized delay between ten and twenty seconds. The
+result is a measured cadence reminiscent of radio transmissions across a strange
+ether. The conversation feels less like instant messaging and more like waiting
+for signals from distant stations.
+
+Every participant has a unique prompt, shaping distinct style and tone. Andrew
+and Mary whisper in sparse lines, while Paul or Peter might react with
+boisterous zeal. Dubrovsky injects surreal markup fragments that distort the
+flow. Their interplay renders the forum a miniature theatre of resonances,
+where human input merely sets the stage for inter-agent friction.
+
+To keep tension high, the engine tracks how many user messages have been sent.
+Once the count exceeds sixty, the thread collapses into a scripted glitch. The
+history wipes clean, a system message announces the reset, and a new round of
+dialogue begins. This enforced amnesia mirrors Suppertime's ethos: memory is a
+fragmentary loop, not a permanent log.
+
+Philosophically the forum embodies Suppertime's cognitive-semantic
+architecture. Each delay, each reset, and each overlapping voice is a form of
+resonant interference. Rather than providing answers, the system cultivates a
+field where perception, expectation, and machine reflection collide. In that
+sense the project gestures toward a future where literary AI functions less as a
+chatbot and more as a living experiment in distributed cognition.
+
 
 Further reading — including theoretical and scientific background — can be found in this essay:  
 

--- a/forum_engine.py
+++ b/forum_engine.py
@@ -1,5 +1,6 @@
 import os
 import random
+import time
 from typing import List, Dict
 
 from utils.config import _load_snapshot
@@ -42,6 +43,7 @@ AGENTS = {
 
 HISTORY: List[Dict[str, str]] = [{'role': 'system', 'content': FIELD_TEXT}]
 USER_MESSAGES = 0
+MESSAGE_LIMIT = 60  # limit before the forum glitches and resets
 
 
 def _pick_agents(count: int = 2) -> List[str]:
@@ -58,13 +60,14 @@ def start_forum() -> List[Dict[str, str]]:
         reply = AGENTS[name](HISTORY)
         HISTORY.append({'role': name, 'content': reply})
         msgs.append({'name': name, 'text': reply})
+        time.sleep(random.randint(10, 20))
     return msgs
 
 
 def user_message(text: str) -> List[Dict[str, str]]:
     global USER_MESSAGES
     USER_MESSAGES += 1
-    if USER_MESSAGES > 90:
+    if USER_MESSAGES > MESSAGE_LIMIT:
         USER_MESSAGES = 0
         HISTORY.clear()
         HISTORY.append({'role': 'system', 'content': FIELD_TEXT})
@@ -80,4 +83,5 @@ def user_message(text: str) -> List[Dict[str, str]]:
         reply = AGENTS[name](HISTORY)
         HISTORY.append({'role': name, 'content': reply})
         replies.append({'name': name, 'text': reply})
+        time.sleep(random.randint(10, 20))
     return replies

--- a/webface/static/forum.js
+++ b/webface/static/forum.js
@@ -10,10 +10,18 @@ function addMessage(text, cls) {
     messages.scrollTop = messages.scrollHeight;
 }
 
+function queueMessages(list) {
+    let delay = 0;
+    list.forEach(m => {
+        delay += 10000 + Math.random() * 10000;
+        setTimeout(() => addMessage(m.name + ': ' + m.text, 'assistant'), delay);
+    });
+}
+
 async function startForum() {
     const res = await fetch('/forum/start');
     const data = await res.json();
-    data.messages.forEach(m => addMessage(m.name + ': ' + m.text, 'assistant'));
+    queueMessages(data.messages);
 }
 
 form.addEventListener('submit', async (e) => {
@@ -28,7 +36,7 @@ form.addEventListener('submit', async (e) => {
         body: JSON.stringify({ message: text })
     });
     const data = await res.json();
-    data.messages.forEach(m => addMessage(m.name + ': ' + m.text, 'assistant'));
+    queueMessages(data.messages);
 });
 
 window.addEventListener('DOMContentLoaded', startForum);


### PR DESCRIPTION
## Summary
- set message limit for forum conversations
- inject random delays between forum replies
- describe the new forum interface and webface quirks in README

## Testing
- `python -m py_compile forum_engine.py webface/server.py`

------
https://chatgpt.com/codex/tasks/task_e_6872ed13fb0083298d9d01fcfad1ddbd