### PR TITLE
Improve forum and persistent memory

### DIFF
--- a/forum_engine.py
+++ b/forum_engine.py
@@ -44,6 +44,7 @@ AGENTS = {
 HISTORY: List[Dict[str, str]] = [{'role': 'system', 'content': FIELD_TEXT}]
 USER_MESSAGES = 0
 MESSAGE_LIMIT = 60  # limit before the forum glitches and resets
+NEW_USER = True
 
 
 def _pick_agents(count: int = 2) -> List[str]:
@@ -52,8 +53,11 @@ def _pick_agents(count: int = 2) -> List[str]:
 
 def start_forum() -> List[Dict[str, str]]:
     """Generate a few opening messages from random agents."""
+    global NEW_USER, USER_MESSAGES
     HISTORY.clear()
     HISTORY.append({'role': 'system', 'content': FIELD_TEXT})
+    USER_MESSAGES = 0
+    NEW_USER = True
     msgs = []
     for _ in range(3):
         name = random.choice(list(AGENTS.keys()))
@@ -65,7 +69,7 @@ def start_forum() -> List[Dict[str, str]]:
 
 
 def user_message(text: str) -> List[Dict[str, str]]:
-    global USER_MESSAGES
+    global USER_MESSAGES, NEW_USER
     USER_MESSAGES += 1
     if USER_MESSAGES > MESSAGE_LIMIT:
         USER_MESSAGES = 0
@@ -80,8 +84,12 @@ def user_message(text: str) -> List[Dict[str, str]]:
 
     replies = []
     for name in triggered:
-        reply = AGENTS[name](HISTORY)
+        extra = []
+        if NEW_USER:
+            extra = [{'role': 'system', 'content': 'A new participant has arrived. Greet them and ask who they are before continuing.'}]
+        reply = AGENTS[name](HISTORY + extra)
         HISTORY.append({'role': name, 'content': reply})
         replies.append({'name': name, 'text': reply})
         time.sleep(random.randint(10, 20))
+    NEW_USER = False
     return replies

--- a/utils/daily_reflection.py
+++ b/utils/daily_reflection.py
@@ -1,0 +1,49 @@
+import os
+import json
+import datetime
+import threading
+from utils.vector_store import add_memory_entry
+from utils.journal import log_event
+
+DATA_PATH = os.getenv("SUPPERTIME_DATA_PATH", "./data")
+JOURNAL_FILE = os.path.join(DATA_PATH, "journal.json")
+OPENAI_KEY = os.getenv("OPENAI_API_KEY")
+
+
+def record_daily_reflection(text):
+    ts = datetime.datetime.utcnow().isoformat()
+    metadata = {"type": "daily_reflection", "ts": ts}
+    vector_id = None
+    try:
+        vector_id = add_memory_entry(text, OPENAI_KEY, metadata)
+    except Exception as e:
+        print(f"[SUPPERTIME][ERROR] Vector log failed: {e}")
+    entry = {**metadata, "text": text, "vector_id": vector_id}
+    log_event(entry)
+    return entry
+
+
+def load_last_reflection():
+    try:
+        with open(JOURNAL_FILE, "r", encoding="utf-8") as f:
+            entries = json.load(f)
+        reflections = [e for e in entries if e.get("type") == "daily_reflection"]
+        if reflections:
+            return sorted(reflections, key=lambda x: x.get("ts", ""))[-1]
+    except Exception:
+        return None
+
+
+def schedule_daily_reflection(get_chapter_title, get_chat_summary):
+    def _loop():
+        while True:
+            now = datetime.datetime.utcnow()
+            next_midnight = (now + datetime.timedelta(days=1)).replace(hour=0, minute=5, second=0, microsecond=0)
+            time.sleep(max(60, (next_midnight - now).total_seconds()))
+            chapter = get_chapter_title() or "Unknown"
+            summary = get_chat_summary()
+            text = f"{datetime.date.today().isoformat()} :: {chapter} :: {summary}"
+            record_daily_reflection(text)
+    thread = threading.Thread(target=_loop, daemon=True)
+    thread.start()
+    return thread


### PR DESCRIPTION
## Summary
- greet new participants in the forum
- add daily reflections to Pinecone memory
- track the last reflection on startup for continuity
- helper to add and fetch vectors

## Testing
- `python -m py_compile forum_engine.py utils/vector_store.py utils/daily_reflection.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_687a70d588608329a44f5356d38d1e33