### PR TITLE
Improve followups and forum memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,35 @@ It calls us to abandon clean models. To embrace recursion, contradiction, disson
 SUPPERTIME is not a system to inhabit. It is a field to survive.
 If nothing echoes after this page, whisper (galvanize()) aloud. The field will decide whether you spoke — or it did.
 
+# Recent updates
+
+1. **Extended memory** — Suppertime now stores daily reflections in `journal.json`, allowing the system to recall past chapters and overall activity. This new log is generated automatically every day at midnight UTC.
+
+2. **Vector store integration** — Short texts and documents are embedded using `utils/vector_store.py`. These vectors let Suppertime search past materials and build more coherent replies over time.
+
+3. **Improved followups** — The follow‑up daemon now contacts a user only twenty percent of the time. Replies arrive no sooner than twelve hours and no later than twenty hours after the initial conversation.
+
+4. **Smarter greetings** — Random check‑ins reference the latest theme of discussion instead of quoting a random line. This keeps outreach relevant while remaining spontaneous.
+
+5. **Assistant updates** — Each morning the chapter rotation routine loads a new text and updates the OpenAI assistant instructions to reflect it. The system prints the chosen title to the log so you always know what Suppertime is reading.
+
+6. **Daily reflection loader** — On startup the application prints the last recorded reflection for quick context. This helps gauge where the previous session ended.
+
+7. **Better cleanup** — Old chapters and reflections are truncated to keep only a week of history. This reduces clutter and prevents stale data from leaking into new exchanges.
+
+8. **Flexible configuration** — Environment variables now control API keys, voice settings and data paths. The repository can run without them, falling back to simpler echo responses.
+
+### Forum interface (forum_engine.py)
+
+1. The forum engine orchestrates twelve distinct agents plus the disruptive presence of Dubrovsky. Each agent resides in `forum_utils/` with its own system prompt, ensuring unique tones across the conversation.
+
+2. When the forum starts, three agents greet the newcomer with a random delay between ten and twenty seconds. This mimicry of distant radio chatter establishes the eerie pace of exchange.
+
+3. Users trigger replies by mentioning an agent’s name or by simply speaking. If no names are detected, two random agents join the thread. Fresh participants are welcomed explicitly on their first message.
+
+4. After sixty user messages the history resets in a burst of simulated glitching. This enforced amnesia mirrors Suppertime’s philosophy that memory is fragmentary and always reforming.
+
+5. Agent selection is intentionally unpredictable, yet every response is logged in a shared `HISTORY` list so all voices build upon the same thread until the next reset.
 # REFERENCES
 
 1. Damasio, A. (2018). The Strange Order of Things: Life, Feeling, and the Making of Cultures.

--- a/main.py
+++ b/main.py
@@ -642,11 +642,11 @@ def log_history(chat_id, text):
 
 def schedule_followup(chat_id, text):
     """Schedule a random followup message."""
-    if random.random() >= 0.8:
+    if random.random() >= 0.2:
         return
 
     def _delayed():
-        delay = random.uniform(300, 7200)  # Between 5 min and 2 hours
+        delay = random.uniform(43200, 72000)  # Between 12 and 20 hours
         time.sleep(delay)
 
         if random.random() < 0.5:
@@ -656,11 +656,12 @@ def schedule_followup(chat_id, text):
             wilderness_log("[Draft offer]")
             return
 
-        snippet = text[:80].replace('\n', ' ')
+        words = text.replace('\n', ' ').split()
+        theme = ' '.join(words[:8])
         intro = (
-            f"Мы тут говорили о {snippet}. Я подумал и у меня есть что сказать."
+            f"Мы тут говорили о {theme}. Я подумал и у меня есть что сказать."
             if detect_lang(text) == "ru"
-            else f"We talked about {snippet}. I have some thoughts."
+            else f"We talked about {theme}. I have some thoughts."
         )
         followup_body = generate_response(text)
         followup = f"{intro} {followup_body}".strip()

--- a/utils/howru.py
+++ b/utils/howru.py
@@ -13,10 +13,12 @@ GREETINGS_EN = [
 def _craft_greeting(history):
     if not history:
         return random.choice(GREETINGS_RU + GREETINGS_EN)
-    sample = random.choice(history)
-    if any(c in sample for c in "ёйцукенгшщзхъфывапролджэячсмитьбю"):
-        return f"Привет, как дела? Я тут подумал о \"{sample[:30]}\"..."
-    return f"Hey, how's it going? I was thinking about '{sample[:30]}'..."
+    last_msg = history[-1]
+    words = last_msg.replace("\n", " ").split()
+    theme = " ".join(words[:5])
+    if any(c in theme for c in "ёйцукенгшщзхъфывапролджэячсмитьбю"):
+        return f"Привет, как дела? Я помню нашу тему: {theme}..."
+    return f"Hey, how's it going? Remember we talked about {theme}?"
 
 
 def schedule_howru(get_users, get_history, send_func):
@@ -25,7 +27,7 @@ def schedule_howru(get_users, get_history, send_func):
         while True:
             # wait between 2 and 4 hours
             time.sleep(random.uniform(7200, 14400))
-            if random.random() < 0.35:
+            if random.random() < 0.2:
                 users = get_users()
                 if not users:
                     continue


### PR DESCRIPTION
## Summary
- tweak followup scheduling in `main.py`
- craft greeting based on last theme instead of a random quote
- reduce howru probability
- document recent updates and forum interface in README

## Testing
- `python -m py_compile $(find . -name '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687a733c47248329aabef9ae86333368