### PR TITLE
Enable CORS for FastAPI services

### DIFF
--- a/main.py
+++ b/main.py
@@ -28,6 +28,7 @@ import asyncio
 import glob
 import base64
 from fastapi import FastAPI, Request, BackgroundTasks
+from fastapi.middleware.cors import CORSMiddleware
 from openai import OpenAI
 from pydub import AudioSegment
 
@@ -1052,6 +1053,13 @@ def handle_voice_message(msg):
 
 # Create FastAPI app
 app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 @app.on_event("startup")
 async def startup_event():

--- a/webface/server.py
+++ b/webface/server.py
@@ -4,6 +4,7 @@ import sys
 from fastapi import FastAPI, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
+from fastapi.middleware.cors import CORSMiddleware
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from openai import OpenAI
@@ -71,6 +72,13 @@ def build_system_prompt(is_group: bool = False) -> str:
 
 BASE_DIR = Path(__file__).resolve().parent
 app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 app.mount("/static", StaticFiles(directory=BASE_DIR / "static"), name="static")
 
 api_key = os.getenv("OPENAI_API_KEY")


### PR DESCRIPTION
## Summary
- enable CORS for the main FastAPI application
- enable CORS for the webface FastAPI server

## Testing
- `pytest`
- `flake8 main.py webface/server.py --select=E9,F63,F7,F82 --show-source --statistics`


------
https://chatgpt.com/codex/tasks/task_e_688d81c9dfcc8329b6dc56b8f38d4061