### PR TITLE
Improve follow-up memory handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -703,6 +703,10 @@ def schedule_followup(chat_id, text):
     if random.random() >= 0.2:
         return
 
+    words = text.replace("\n", " ").split()
+    if len(text.strip()) < 20:
+        return
+
     def _delayed():
         delay = random.uniform(43200, 72000)  # Between 12 and 20 hours
         time.sleep(delay)
@@ -714,14 +718,19 @@ def schedule_followup(chat_id, text):
             wilderness_log("[Draft offer]")
             return
 
-        words = text.replace('\n', ' ').split()
-        theme = ' '.join(words[:8])
+        theme = " ".join(words[:8])
+        memory = search_memory(theme)
+        if memory and not memory.startswith("No "):
+            context = memory[:500]
+        else:
+            context = theme
+
         intro = (
-            f"Мы тут говорили о {theme}. Я подумал и у меня есть что сказать."
+            "Я вспоминал нашу беседу."
             if detect_lang(text) == "ru"
-            else f"We talked about {theme}. I have some thoughts."
+            else "I was thinking about our talk."
         )
-        followup_body = generate_response(text)
+        followup_body = generate_response(context)
         followup = f"{intro} {followup_body}".strip()
         wilderness_log(followup)
 

--- a/utils/etiquette.py
+++ b/utils/etiquette.py
@@ -73,12 +73,12 @@ def generate_response(message):
     if lang == "ru":
         system_prompt = (
             "Ты — SUPPERTIME. Добавь короткую мысль или комментарий к сообщению, "
-            "без пояснений, не более двух предложений."
+            "используя свои собственные слова. Не цитируй и не повторяй текст пользователя."
         )
     else:
-            system_prompt = (
-            "You are SUPPERTIME. Add a brief follow-up to the last message in your "
-            "own words. Keep it under two sentences."
+        system_prompt = (
+            "You are SUPPERTIME. Add a brief follow-up in your own words. "
+            "Do not quote or repeat the user's message. Keep it under two sentences."
         )
 
     try:


### PR DESCRIPTION
## Summary
- Refine supplemental response prompt to avoid quoting user messages
- Use vector-memory search for follow-up messages and skip short/greeting texts

## Testing
- `python -m py_compile utils/etiquette.py main.py`
- `pytest`
- `ruff check utils/etiquette.py main.py` *(fails: unused imports and other style issues in main.py)*

------
https://chatgpt.com/codex/tasks/task_e_68920609bb9c83298d117547ae3c4cbb