### PR TITLE
Add agent-specific styles and avatars

### DIFF
--- a/webface/static/forum.js
+++ b/webface/static/forum.js
@@ -2,10 +2,28 @@ const form = document.getElementById('chat-form');
 const input = document.getElementById('chat-input');
 const messages = document.getElementById('messages');
 
-function addMessage(text, cls) {
+function agentClass(name) {
+    return 'agent-' + name.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+}
+
+function addMessage(text, cls, name) {
     const div = document.createElement('div');
     div.className = 'message ' + cls;
-    div.textContent = text;
+    if (name) {
+        const avatar = document.createElement('span');
+        avatar.className = 'avatar';
+        avatar.textContent = name[0];
+        div.appendChild(avatar);
+
+        const nameSpan = document.createElement('span');
+        nameSpan.className = 'name';
+        nameSpan.textContent = name;
+        div.appendChild(nameSpan);
+
+        div.appendChild(document.createTextNode(': ' + text));
+    } else {
+        div.textContent = text;
+    }
     messages.appendChild(div);
     messages.scrollTop = messages.scrollHeight;
 }
@@ -14,7 +32,7 @@ function queueMessages(list) {
     let delay = 0;
     list.forEach(m => {
         delay += 10000 + Math.random() * 10000;
-        setTimeout(() => addMessage(m.name + ': ' + m.text, 'assistant'), delay);
+        setTimeout(() => addMessage(m.text, agentClass(m.name), m.name), delay);
     });
 }
 

--- a/webface/static/style.css
+++ b/webface/static/style.css
@@ -51,6 +51,56 @@ button {
     text-align: right;
 }
 
+.message[class*='agent-'] {
+    display: flex;
+    align-items: center;
+    padding: 4px 8px;
+    border-radius: 6px;
+}
+
+.message .avatar {
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-right: 6px;
+    font-size: 12px;
+    color: #fff;
+    flex-shrink: 0;
+}
+
+.message .name {
+    font-weight: bold;
+    margin-right: 4px;
+}
+
+.message.agent-andrew { background: #e6f0ff; }
+.message.agent-andrew .avatar { background: #4e7dff; }
+.message.agent-dubrovsky { background: #ffe6e6; }
+.message.agent-dubrovsky .avatar { background: #ff4e4e; }
+.message.agent-jan { background: #e6ffe6; }
+.message.agent-jan .avatar { background: #4eff4e; }
+.message.agent-judas { background: #fff1e6; }
+.message.agent-judas .avatar { background: #ff9c4e; }
+.message.agent-mark { background: #f0e6ff; }
+.message.agent-mark .avatar { background: #a94eff; }
+.message.agent-mary { background: #ffe6f7; }
+.message.agent-mary .avatar { background: #ff4ecb; }
+.message.agent-matthew { background: #e6fff7; }
+.message.agent-matthew .avatar { background: #4effc3; }
+.message.agent-paul { background: #fffde6; }
+.message.agent-paul .avatar { background: #ffd84e; }
+.message.agent-peter { background: #e6f7ff; }
+.message.agent-peter .avatar { background: #4ecbff; }
+.message.agent-thomas { background: #f7e6ff; }
+.message.agent-thomas .avatar { background: #cb4eff; }
+.message.agent-yakov { background: #e6fff0; }
+.message.agent-yakov .avatar { background: #4eff9c; }
+.message.agent-yeshu { background: #fff0e6; }
+.message.agent-yeshu .avatar { background: #ff6f4e; }
+
 @keyframes stretch {
     0% { transform: scale(1); }
     50% { transform: scale(1.2); }


### PR DESCRIPTION
## Summary
- add per-agent CSS class and initial avatar when rendering forum messages
- style each agent with unique colors and avatar backgrounds

## Testing
- `python -m pytest`
- `node --check webface/static/forum.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_68938a402e98832997ca1761eb2347bc