### PR TITLE
feat: avoid echoing greetings in howru

### DIFF
--- a/tests/test_howru.py
+++ b/tests/test_howru.py
@@ -1,0 +1,23 @@
+import re
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from utils import howru
+
+
+def test_uses_last_non_greeting_message():
+    howru.openai_client = None
+    history = ["привет", "расскажи о космосе", "как дела"]
+    msg = howru._craft_greeting(history)
+    assert "космос" in msg.lower()
+
+
+def test_skips_generic_phrase_echo():
+    howru.openai_client = None
+    history = ["привет", "как дела", "привет", "обсудим проект"]
+    msg = howru._craft_greeting(history)
+    # Extract the theme part if present
+    if ":" in msg:
+        theme = msg.split(":", 1)[1].lower()
+        assert "привет" not in theme and "как дела" not in theme

--- a/utils/howru.py
+++ b/utils/howru.py
@@ -1,7 +1,8 @@
+import os
 import random
 import threading
 import time
-from datetime import datetime
+from openai import OpenAI
 
 GREETINGS_RU = [
     "Эй, как дела?", "Привет! Что нового?", "Хэй, как ты?", "Как настроение?"
@@ -10,12 +11,69 @@ GREETINGS_EN = [
     "Hey, how are you?", "Hi there, all good?", "Hello! How's it going?", "Yo, how's life?"
 ]
 
+GENERIC_PHRASES = [
+    "привет", "как дела", "hello", "hi", "hey", "здравствуйте"
+]
+
+api_key = os.getenv("OPENAI_API_KEY")
+openai_client = OpenAI(api_key=api_key) if api_key else None
+
+
+def _clean_message(msg: str) -> str:
+    text = msg.lower()
+    for phrase in GENERIC_PHRASES:
+        text = text.replace(phrase, "")
+    return " ".join(text.split()).strip()
+
+
+def _last_non_greeting(history):
+    for msg in reversed(history):
+        if _clean_message(msg):
+            return msg
+    return None
+
+
+def _summarize_context(history):
+    if not openai_client:
+        return None
+    cleaned = [_clean_message(m) for m in history if _clean_message(m)]
+    if not cleaned:
+        return None
+    recent = "\n".join(cleaned[-5:])
+    try:
+        response = openai_client.chat.completions.create(
+            model="gpt-4.1-mini",
+            messages=[
+                {"role": "system", "content": "Summarize the conversation context in 5-10 words."},
+                {"role": "user", "content": recent},
+            ],
+            max_tokens=40,
+            temperature=0.7,
+        )
+        return response.choices[0].message.content.strip()
+    except Exception:
+        return None
+
 def _craft_greeting(history):
     if not history:
         return random.choice(GREETINGS_RU + GREETINGS_EN)
-    last_msg = history[-1]
-    words = last_msg.replace("\n", " ").split()
-    theme = " ".join(words[:5])
+    last_msg = _last_non_greeting(history)
+    if not last_msg:
+        return random.choice(GREETINGS_RU + GREETINGS_EN)
+
+    summary = None
+    if len(history) > 2 and random.random() < 0.5:
+        summary = _summarize_context(history)
+
+    if summary:
+        theme = summary
+    else:
+        words = _clean_message(last_msg).split()
+        theme = " ".join(words[:5])
+
+    if not theme:
+        return random.choice(GREETINGS_RU + GREETINGS_EN)
+
     if any(c in theme for c in "ёйцукенгшщзхъфывапролджэячсмитьбю"):
         return f"Привет, как дела? Я помню нашу тему: {theme}..."
     return f"Hey, how's it going? Remember we talked about {theme}?"


### PR DESCRIPTION
## Summary
- track last non-greeting message and craft follow-up from it
- skip generic phrases and optionally summarise recent chat context via OpenAI
- add tests ensuring we don't repeat user's greeting text

## Testing
- `python -m py_compile utils/howru.py tests/test_howru.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68938a6dbe8c8329b1cbe352fb21333f