### PR TITLE
Use session token for chat history

### DIFF
--- a/webface/static/chat.js
+++ b/webface/static/chat.js
@@ -96,10 +96,10 @@ form.addEventListener('submit', async (e) => {
     button.disabled = true;
     spinner.classList.remove('hidden');
     try {
-        const res = await fetch('/chat', {
+        const res = await fetch('/chat?session_id=' + encodeURIComponent(sessionId), {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ message: text, session_id: sessionId })
+            body: JSON.stringify({ message: text })
         });
         if (!res.ok) {
             throw new Error(res.statusText || 'Network error');
@@ -126,10 +126,8 @@ form.addEventListener('submit', async (e) => {
 });
 
 async function clearHistory() {
-    await fetch('/chat/clear', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ session_id: sessionId })
+    await fetch('/chat/clear?session_id=' + encodeURIComponent(sessionId), {
+        method: 'POST'
     });
     messages.innerHTML = '';
 }


### PR DESCRIPTION
## Summary
- manage chat history per session with a dictionary keyed by a session ID
- `/chat` now reads the session token from cookies or query params and assigns one when missing
- `chat.js` sends the session token on each chat and clear request

## Testing
- `pytest`
- `flake8 webface/server.py` *(fails: E402, E501 and other existing style issues)*

------
https://chatgpt.com/codex/tasks/task_e_68939158ce888329a28e0b8c880cb3eb