### PR TITLE
Add responsive layout and message metadata

### DIFF
--- a/webface/static/chat.js
+++ b/webface/static/chat.js
@@ -4,6 +4,7 @@ const messages = document.getElementById('messages');
 const chat = document.getElementById('chat');
 const button = form.querySelector('button');
 const spinner = document.getElementById('spinner');
+const template = document.getElementById('message-template');
 
 let startTime = Date.now();
 let lastGlitch = 0;
@@ -55,11 +56,14 @@ function checkGlitch() {
 
 setInterval(checkGlitch, 30000);
 
-function addMessage(text, cls) {
-    const div = document.createElement('div');
-    div.className = 'message ' + cls;
-    div.textContent = text;
-    messages.appendChild(div);
+function addMessage(text, cls, role) {
+    const node = template.content.cloneNode(true);
+    const div = node.querySelector('.message');
+    div.classList.add(cls);
+    node.querySelector('.role-badge').textContent = role || cls;
+    node.querySelector('.text').textContent = text;
+    node.querySelector('.timestamp').textContent = new Date().toLocaleTimeString();
+    messages.appendChild(node);
     messages.scrollTop = messages.scrollHeight;
 }
 

--- a/webface/static/forum.html
+++ b/webface/static/forum.html
@@ -9,14 +9,26 @@
 <body>
     <header>
         <h1>SUPPERTIME FORUM</h1>
+        <nav>
+            <a href="/static/index.html">Chat</a>
+            <a href="/static/forum.html">Forum</a>
+        </nav>
     </header>
     <main id="chat">
-        <div id="messages"></div>
+        <section id="messages"></section>
         <form id="chat-form">
             <input type="text" id="chat-input" autocomplete="off" placeholder="Type your message" />
             <button type="submit">Send</button>
         </form>
     </main>
+    <aside id="info"></aside>
+    <template id="message-template">
+        <div class="message">
+            <span class="role-badge"></span>
+            <span class="text"></span>
+            <span class="timestamp"></span>
+        </div>
+    </template>
     <script src="/static/forum.js"></script>
 </body>
 </html>

--- a/webface/static/forum.js
+++ b/webface/static/forum.js
@@ -1,30 +1,20 @@
 const form = document.getElementById('chat-form');
 const input = document.getElementById('chat-input');
 const messages = document.getElementById('messages');
+const template = document.getElementById('message-template');
 
 function agentClass(name) {
     return 'agent-' + name.toLowerCase().replace(/[^a-z0-9]+/g, '-');
 }
 
-function addMessage(text, cls, name) {
-    const div = document.createElement('div');
-    div.className = 'message ' + cls;
-    if (name) {
-        const avatar = document.createElement('span');
-        avatar.className = 'avatar';
-        avatar.textContent = name[0];
-        div.appendChild(avatar);
-
-        const nameSpan = document.createElement('span');
-        nameSpan.className = 'name';
-        nameSpan.textContent = name;
-        div.appendChild(nameSpan);
-
-        div.appendChild(document.createTextNode(': ' + text));
-    } else {
-        div.textContent = text;
-    }
-    messages.appendChild(div);
+function addMessage(text, cls, role) {
+    const node = template.content.cloneNode(true);
+    const div = node.querySelector('.message');
+    div.classList.add(cls);
+    node.querySelector('.role-badge').textContent = role || cls;
+    node.querySelector('.text').textContent = text;
+    node.querySelector('.timestamp').textContent = new Date().toLocaleTimeString();
+    messages.appendChild(node);
     messages.scrollTop = messages.scrollHeight;
 }
 
@@ -46,7 +36,7 @@ form.addEventListener('submit', async (e) => {
     e.preventDefault();
     const text = input.value.trim();
     if (!text) return;
-    addMessage(text, 'user');
+    addMessage(text, 'user', 'You');
     input.value = '';
     const res = await fetch('/forum/chat', {
         method: 'POST',

--- a/webface/static/index.html
+++ b/webface/static/index.html
@@ -11,18 +11,29 @@
     <header>
         <h1>SUPPERTIME (v&#8734;)</h1>
         <h2>Arianna Method</h2>
+        <nav>
+            <a href="/static/index.html">Chat</a>
+            <a href="/static/forum.html">Forum</a>
+        </nav>
     </header>
     <main id="chat">
-        <div id="messages"></div>
+        <section id="messages"></section>
         <form id="chat-form">
             <input type="text" id="chat-input" autocomplete="off" placeholder="Type your message" />
             <button type="submit">Send</button>
             <div id="spinner" class="spinner hidden"></div>
         </form>
     </main>
-    <div id="overlay" class="hidden">
+    <aside id="overlay" class="hidden">
         <iframe id="overlay-frame" src="" frameborder="0"></iframe>
-    </div>
+    </aside>
+    <template id="message-template">
+        <div class="message">
+            <span class="role-badge"></span>
+            <span class="text"></span>
+            <span class="timestamp"></span>
+        </div>
+    </template>
     <script src="/static/chat.js"></script>
     <script>
         if ('serviceWorker' in navigator) {

--- a/webface/static/style.css
+++ b/webface/static/style.css
@@ -1,7 +1,24 @@
+/* theme variables */
+:root {
+    --bg-color: #ffffff;
+    --text-color: #000000;
+    --primary-color: #000000;
+    --secondary-color: #ffffff;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-color: #000000;
+        --text-color: #ffffff;
+        --primary-color: #ffffff;
+        --secondary-color: #000000;
+    }
+}
+
 body {
     font-family: -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Helvetica, Arial, sans-serif;
-    background: #ffffff;
-    color: #000000;
+    background: var(--bg-color);
+    color: var(--text-color);
     margin: 0;
     display: flex;
     flex-direction: column;
@@ -10,6 +27,19 @@ body {
 header {
     text-align: center;
     padding: 20px 0;
+}
+
+nav {
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+    padding-bottom: 10px;
+}
+
+nav a {
+    color: var(--text-color);
+    text-decoration: none;
 }
 #chat {
     flex: 1;
@@ -26,6 +56,8 @@ header {
 }
 #chat-form {
     display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
     padding: 10px 20px;
 }
 #chat-input {
@@ -40,9 +72,25 @@ button {
     padding: 10px 20px;
     font-size: 16px;
     border: none;
-    background: #000;
-    color: #fff;
+    background: var(--primary-color);
+    color: var(--secondary-color);
     border-radius: 6px;
+}
+
+.role-badge {
+    display: inline-block;
+    padding: 2px 6px;
+    background: var(--primary-color);
+    color: var(--secondary-color);
+    border-radius: 4px;
+    font-size: 0.75rem;
+    margin-right: 6px;
+}
+
+.timestamp {
+    margin-left: 6px;
+    font-size: 0.75rem;
+    opacity: 0.7;
 }
 
 .hidden {
@@ -158,4 +206,20 @@ button {
     width: 90%;
     height: 90%;
     border: none;
+}
+
+@media (max-width: 600px) {
+    #chat-form {
+        flex-direction: column;
+    }
+    button {
+        margin-left: 0;
+        width: 100%;
+    }
+}
+
+@media (min-width: 900px) {
+    #chat {
+        max-width: 800px;
+    }
 }


### PR DESCRIPTION
## Summary
- add dark-mode variables, responsive breakpoints and role/timestamp styles
- introduce navigation and semantic HTML wrappers for chat and forum pages
- render role badges and timestamps for messages in chat and forum scripts

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893917e46608329b8bb38ae53a28efe