### PR TITLE
Add distinct user and assistant message styling

### DIFF
--- a/webface/static/chat.js
+++ b/webface/static/chat.js
@@ -58,7 +58,14 @@ setInterval(checkGlitch, 30000);
 function addMessage(text, cls) {
     const div = document.createElement('div');
     div.className = 'message ' + cls;
+    if (text.length > 120) {
+        div.classList.add('long');
+    }
     div.textContent = text;
+    const time = document.createElement('span');
+    time.className = 'timestamp';
+    time.textContent = new Date().toLocaleTimeString();
+    div.appendChild(time);
     messages.appendChild(div);
     messages.scrollTop = messages.scrollHeight;
 }

--- a/webface/static/forum.js
+++ b/webface/static/forum.js
@@ -9,6 +9,9 @@ function agentClass(name) {
 function addMessage(text, cls, name) {
     const div = document.createElement('div');
     div.className = 'message ' + cls;
+    if (text.length > 120) {
+        div.classList.add('long');
+    }
     if (name) {
         const avatar = document.createElement('span');
         avatar.className = 'avatar';
@@ -24,6 +27,10 @@ function addMessage(text, cls, name) {
     } else {
         div.textContent = text;
     }
+    const time = document.createElement('span');
+    time.className = 'timestamp';
+    time.textContent = new Date().toLocaleTimeString();
+    div.appendChild(time);
     messages.appendChild(div);
     messages.scrollTop = messages.scrollHeight;
 }
@@ -32,7 +39,7 @@ function queueMessages(list) {
     let delay = 0;
     list.forEach(m => {
         delay += 10000 + Math.random() * 10000;
-        setTimeout(() => addMessage(m.text, agentClass(m.name), m.name), delay);
+        setTimeout(() => addMessage(m.text, 'assistant ' + agentClass(m.name), m.name), delay);
     });
 }
 

--- a/webface/static/style.css
+++ b/webface/static/style.css
@@ -58,11 +58,37 @@ button {
     border-radius: 50%;
     animation: spin 1s linear infinite;
 }
+
 .message {
     margin: 10px 0;
 }
+
 .message.user {
     text-align: right;
+    background: #dcf8c6;
+    border: 1px solid #b2d8a3;
+    border-radius: 12px 12px 0 12px;
+    display: inline-block;
+    padding: 6px 10px;
+}
+
+.message.assistant {
+    background: #f1f1f1;
+    border: 1px solid #ccc;
+    border-radius: 12px 12px 12px 0;
+    display: inline-block;
+    padding: 6px 10px;
+}
+
+.message.long {
+    font-size: 0.9em;
+}
+
+.message .timestamp {
+    display: block;
+    font-size: 0.75em;
+    color: #666;
+    margin-top: 2px;
 }
 
 .message[class*='agent-'] {


### PR DESCRIPTION
## Summary
- style user vs assistant message bubbles with unique backgrounds, borders, and radii
- show timestamps and shrink font on long messages
- tag forum responses as assistant messages

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689392965c2c832985025dc88cb652be