### PR TITLE
Refine greeting crafting with fallback topics

### DIFF
--- a/tests/test_howru.py
+++ b/tests/test_howru.py
@@ -1,4 +1,4 @@
-import re
+import random
 import sys
 from pathlib import Path
 
@@ -21,3 +21,33 @@ def test_skips_generic_phrase_echo():
     if ":" in msg:
         theme = msg.split(":", 1)[1].lower()
         assert "привет" not in theme and "как дела" not in theme
+
+
+def test_uses_earlier_message_when_last_is_greeting():
+    howru.openai_client = None
+    random.seed(0)
+    history = ["привет", "давай обсудим проект", "hi"]
+    msg = howru._craft_greeting(history)
+    assert "проект" in msg.lower()
+
+
+def test_uses_prepared_topic_if_no_history_theme():
+    howru.openai_client = None
+    random.seed(0)
+    history = ["привет", "hi", "ok"]
+    msg = howru._craft_greeting(history)
+    assert "favorite books" in msg.lower()
+
+
+def test_fallback_message_when_no_topic_available():
+    howru.openai_client = None
+    backup = howru.DEFAULT_TOPICS
+    howru.DEFAULT_TOPICS = []
+    random.seed(0)
+    history = ["привет", "hi"]
+    msg = howru._craft_greeting(history)
+    assert msg in {
+        "Привет! Как проходит твой день?",
+        "Hey there! How's your day going?",
+    }
+    howru.DEFAULT_TOPICS = backup


### PR DESCRIPTION
## Summary
- Skip typical greetings and very short messages when crafting chat greetings
- Use prepared topics or fallback messages when no conversation theme is found
- Expand tests to cover new greeting logic and fallbacks

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689393da6cd083299afcf5871d5dd44a