### PR TITLE
feat: track chat sessions

### DIFF
--- a/webface/static/chat.js
+++ b/webface/static/chat.js
@@ -80,9 +80,15 @@ function hidePage() {
     overlay.classList.add('hidden');
     const version = overlay.dataset.version;
     overlay.dataset.version = '';
-    fetch('/after_read?version=' + (version || ''))
+    fetch('/after_read?version=' + (version || '') + '&session_id=' + encodeURIComponent(sessionId))
         .then(r => r.json())
-        .then(d => addMessage(d.reply, 'assistant'));
+        .then(d => {
+            if (d.session_id && d.session_id !== sessionId) {
+                sessionId = d.session_id;
+                localStorage.setItem('session_id', sessionId);
+            }
+            addMessage(d.reply, 'assistant');
+        });
 }
 
 window.addEventListener('message', (e) => {


### PR DESCRIPTION
## Summary
- Track chat sessions with helper that sets a `session_id` cookie
- Use per-session history for `/chat` and `/after_read` routes
- Send `session_id` from client when closing pages

## Testing
- `flake8 webface/server.py` *(fails: E402, E501, E305, E302)*
- `node --check webface/static/chat.js`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893947048e4832988f0e5edf640e406