### PR TITLE
feat: add theming and message styling

### DIFF
--- a/webface/static/chat.js
+++ b/webface/static/chat.js
@@ -5,6 +5,7 @@ const chat = document.getElementById('chat');
 const button = form.querySelector('button');
 const spinner = document.getElementById('spinner');
 const template = document.getElementById('message-template');
+const themeToggle = document.getElementById('theme-toggle');
 
 let startTime = Date.now();
 let lastGlitch = 0;
@@ -14,6 +15,16 @@ if (!sessionId) {
     sessionId = (self.crypto && crypto.randomUUID) ? crypto.randomUUID() : Math.random().toString(36).slice(2);
     localStorage.setItem('session_id', sessionId);
 }
+
+const savedTheme = localStorage.getItem('theme');
+if (savedTheme === 'dark') {
+    document.body.classList.add('dark');
+}
+
+themeToggle.addEventListener('click', () => {
+    document.body.classList.toggle('dark');
+    localStorage.setItem('theme', document.body.classList.contains('dark') ? 'dark' : 'light');
+});
 
 const stretchLines = [
     'ой нет! опять! :-)',
@@ -60,7 +71,10 @@ function addMessage(text, cls, role) {
     const node = template.content.cloneNode(true);
     const div = node.querySelector('.message');
     div.classList.add(cls);
-    node.querySelector('.role-badge').textContent = role || cls;
+    div.classList.add(cls === 'user' ? 'user' : 'assistant');
+    const name = role || (cls === 'user' ? 'You' : 'Assistant');
+    node.querySelector('.name').textContent = name;
+    node.querySelector('.avatar').textContent = name[0].toUpperCase();
     node.querySelector('.text').textContent = text;
     node.querySelector('.timestamp').textContent = new Date().toLocaleTimeString();
     messages.appendChild(node);

--- a/webface/static/forum.html
+++ b/webface/static/forum.html
@@ -12,6 +12,7 @@
         <nav>
             <a href="/static/index.html">Chat</a>
             <a href="/static/forum.html">Forum</a>
+            <button id="theme-toggle" type="button">🌓</button>
         </nav>
     </header>
     <main id="chat">
@@ -24,7 +25,8 @@
     <aside id="info"></aside>
     <template id="message-template">
         <div class="message">
-            <span class="role-badge"></span>
+            <span class="avatar"></span>
+            <span class="name"></span>
             <span class="text"></span>
             <span class="timestamp"></span>
         </div>

--- a/webface/static/forum.js
+++ b/webface/static/forum.js
@@ -2,16 +2,31 @@ const form = document.getElementById('chat-form');
 const input = document.getElementById('chat-input');
 const messages = document.getElementById('messages');
 const template = document.getElementById('message-template');
+const themeToggle = document.getElementById('theme-toggle');
 
 function agentClass(name) {
     return 'agent-' + name.toLowerCase().replace(/[^a-z0-9]+/g, '-');
 }
 
+const savedTheme = localStorage.getItem('theme');
+if (savedTheme === 'dark') {
+    document.body.classList.add('dark');
+}
+
+themeToggle.addEventListener('click', () => {
+    document.body.classList.toggle('dark');
+    localStorage.setItem('theme', document.body.classList.contains('dark') ? 'dark' : 'light');
+});
+
 function addMessage(text, cls, role) {
     const node = template.content.cloneNode(true);
     const div = node.querySelector('.message');
-    div.classList.add(cls);
-    node.querySelector('.role-badge').textContent = role || cls;
+    if (cls) div.classList.add(cls);
+    const isUser = role === 'You' || cls === 'user';
+    div.classList.add(isUser ? 'user' : 'assistant');
+    const name = role || (isUser ? 'You' : 'Assistant');
+    node.querySelector('.name').textContent = name;
+    node.querySelector('.avatar').textContent = name[0].toUpperCase();
     node.querySelector('.text').textContent = text;
     node.querySelector('.timestamp').textContent = new Date().toLocaleTimeString();
     messages.appendChild(node);

--- a/webface/static/index.html
+++ b/webface/static/index.html
@@ -14,6 +14,7 @@
         <nav>
             <a href="/static/index.html">Chat</a>
             <a href="/static/forum.html">Forum</a>
+            <button id="theme-toggle" type="button">🌓</button>
         </nav>
     </header>
     <main id="chat">
@@ -29,7 +30,8 @@
     </aside>
     <template id="message-template">
         <div class="message">
-            <span class="role-badge"></span>
+            <span class="avatar"></span>
+            <span class="name"></span>
             <span class="text"></span>
             <span class="timestamp"></span>
         </div>

--- a/webface/static/style.css
+++ b/webface/static/style.css
@@ -4,6 +4,8 @@
     --text-color: #000000;
     --primary-color: #000000;
     --secondary-color: #ffffff;
+    --assistant-bg: #f3f3f3;
+    --user-bg: #d1e7dd;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -12,7 +14,18 @@
         --text-color: #ffffff;
         --primary-color: #ffffff;
         --secondary-color: #000000;
+        --assistant-bg: #333333;
+        --user-bg: #264d26;
     }
+}
+
+body.dark {
+    --bg-color: #000000;
+    --text-color: #ffffff;
+    --primary-color: #ffffff;
+    --secondary-color: #000000;
+    --assistant-bg: #333333;
+    --user-bg: #264d26;
 }
 
 body {
@@ -77,14 +90,13 @@ button {
     border-radius: 6px;
 }
 
-.role-badge {
-    display: inline-block;
-    padding: 2px 6px;
-    background: var(--primary-color);
-    color: var(--secondary-color);
+#theme-toggle {
+    background: none;
+    color: var(--text-color);
+    border: 1px solid var(--text-color);
+    margin-left: 1rem;
+    padding: 6px 10px;
     border-radius: 4px;
-    font-size: 0.75rem;
-    margin-right: 6px;
 }
 
 .timestamp {
@@ -106,18 +118,34 @@ button {
     border-radius: 50%;
     animation: spin 1s linear infinite;
 }
+
 .message {
     margin: 10px 0;
+    padding: 8px;
+    border-radius: 6px;
+    display: flex;
+    align-items: flex-start;
+    gap: 4px;
+    max-width: 80%;
 }
+
 .message.user {
+    margin-left: auto;
+    background: var(--user-bg);
+    border-radius: 12px 12px 0 12px;
     text-align: right;
 }
 
+.message.assistant {
+    margin-right: auto;
+    background: var(--assistant-bg);
+    border-radius: 12px 12px 12px 0;
+}
+
 .message[class*='agent-'] {
-    display: flex;
-    align-items: center;
+    margin-right: auto;
+    border-radius: 12px 12px 12px 0;
     padding: 4px 8px;
-    border-radius: 6px;
 }
 
 .message .avatar {
@@ -131,6 +159,15 @@ button {
     font-size: 12px;
     color: #fff;
     flex-shrink: 0;
+}
+
+.message.user .avatar {
+    display: none;
+}
+
+.message.assistant .avatar {
+    background: var(--primary-color);
+    color: var(--secondary-color);
 }
 
 .message .name {
@@ -209,6 +246,12 @@ button {
 }
 
 @media (max-width: 600px) {
+    nav {
+        flex-direction: column;
+    }
+    #messages {
+        padding: 0 10px;
+    }
     #chat-form {
         flex-direction: column;
     }


### PR DESCRIPTION
## Summary
- add dedicated styles for user and assistant messages
- support light/dark theme toggle and mobile-friendly layout
- render avatars and names for chat and forum messages

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893947efb588329b0909afc59d517d4