### PR TITLE
Improve chat fallback behaviour when OpenAI is unavailable

### DIFF
--- a/tests/test_chat_fallback.py
+++ b/tests/test_chat_fallback.py
@@ -1,0 +1,46 @@
+import sys
+from pathlib import Path
+import types
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+# Stub vector_store to avoid network calls during import
+stub_vs = types.ModuleType("utils.vector_store")
+stub_vs.vectorize_file = lambda *a, **k: None
+stub_vs.semantic_search_in_file = lambda *a, **k: []
+sys.modules["utils.vector_store"] = stub_vs
+
+from fastapi.testclient import TestClient
+from webface import server
+
+
+class DummyChatCompletions:
+    def create(self, *args, **kwargs):
+        class Msg:
+            content = "model says hi"
+        class Choice:
+            message = Msg()
+        class Resp:
+            choices = [Choice()]
+        return Resp()
+
+
+class DummyClient:
+    chat = type("obj", (), {"completions": DummyChatCompletions()})()
+
+
+def test_fallback_without_api_key():
+    server.openai_client = None
+    client = TestClient(server.app)
+    resp = client.post("/chat", json={"message": "test message"})
+    data = resp.json()
+    assert "api" in data["reply"].lower()
+    assert "test message" not in data["reply"].lower()
+
+
+def test_with_openai_client_stub():
+    server.openai_client = DummyClient()
+    client = TestClient(server.app)
+    resp = client.post("/chat", json={"message": "whatever"})
+    data = resp.json()
+    assert data["reply"] == "model says hi"

--- a/webface/server.py
+++ b/webface/server.py
@@ -4,6 +4,7 @@ import sys
 import uuid
 import asyncio
 import time
+import logging
 from fastapi import FastAPI, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
@@ -14,6 +15,8 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from openai import OpenAI
 from utils.config import _load_snapshot
 from forum_engine import start_forum, user_message
+
+logger = logging.getLogger(__name__)
 
 INTRO = (
     "Hey yo, SUPPERTIME! You’re on the right fucking path. [FR] Cette merde est ton phare — il te garde en résonance. \n"
@@ -77,6 +80,20 @@ def build_system_prompt(is_group: bool = False, summary: str = "") -> str:
     if summary:
         return f"{base}\n\nConversation summary:\n{summary}"
     return base
+
+
+def _fallback_reply(text: str) -> str:
+    """Return a simple rule-based reply when the OpenAI client is unavailable."""
+    lower = text.lower()
+    templates = {
+        "привет": "Привет! Сейчас я отвечаю без модели — возможности ограничены.",
+        "hello": "Hi! API недоступно, отвечаю по заготовкам.",
+        "кто ты": "Я локальный бот Suppertime без доступа к OpenAI API.",
+    }
+    for key, value in templates.items():
+        if key in lower:
+            return value
+    return "OpenAI API недоступно, поэтому мой ответ ограничен." 
 
 BASE_DIR = Path(__file__).resolve().parent
 app = FastAPI()
@@ -192,7 +209,10 @@ async def chat(request: Request):
     system_prompt = build_system_prompt(summary=session.get("summary", ""))
     messages = [{"role": "system", "content": system_prompt}] + history[-HISTORY_RECENT_LIMIT:]
 
-    if openai_client:
+    if not openai_client:
+        logger.warning("OpenAI client not configured; using fallback response")
+        reply = _fallback_reply(text)
+    else:
         try:
             resp = openai_client.chat.completions.create(
                 model="gpt-4.1",
@@ -201,10 +221,9 @@ async def chat(request: Request):
                 max_tokens=200,
             )
             reply = resp.choices[0].message.content.strip()
-        except Exception:
-            reply = "..."
-    else:
-        reply = f"Echo: {text}"
+        except Exception as e:
+            logger.error("OpenAI API error: %s", e)
+            reply = _fallback_reply(text)
 
     lower = text.lower()
     if EXPECTING_VERSION:


### PR DESCRIPTION
## Summary
- add rule-based `_fallback_reply` for offline responses
- handle missing or failing OpenAI client with logging
- test fallback behaviour with and without a stubbed OpenAI client

## Testing
- `python -m pytest tests/test_chat_fallback.py::test_fallback_without_api_key -q`
- `python -m pytest tests/test_chat_fallback.py::test_with_openai_client_stub -q`
- `python -m pytest -q`
- `flake8 webface/server.py tests/test_chat_fallback.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689394c370108329838cc258fa0bc260