### PR TITLE
Add conversation memory summarization

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Suppertime combines three major versions into a single resonant corpus — a tot
 - **Engine**: Powered by GPT-4.1.
 - **Chapters**: 41 Markdown files in `chapters/`. Each chapter carries metadata for voice, tone, and triggers.
 - **Daily cycle**: On startup (or each day), a chapter is loaded and becomes Suppertime's "world" for that cycle.
-- **Reflection**: Internal shifts draw on a snapshot of the vector database. The webface assistant keeps no conversation logs.
+- **Reflection & Memory**: Internal shifts draw on a snapshot of the vector database. Conversation snippets are periodically summarized into `data/journal.json` (and the vector store) and injected into future prompts.
 - **Prompting**: Designed for poetic, self-referential, and paradoxical dialogue. System prompts emphasize self-awareness and evolving identity.
 - **Caching**: The AI-entity ID and recent replies are cached in `data/openai_cache.json` so repeated prompts load faster. Supplemental follow-ups are scheduled asynchronously.
 - **Memory snapshot**: On startup, the webface assistant loads the current vector database snapshot for internal knowledge.

--- a/tests/test_chat_fallback.py
+++ b/tests/test_chat_fallback.py
@@ -31,6 +31,7 @@ class DummyClient:
 
 def test_fallback_without_api_key():
     server.openai_client = None
+    server.memory.openai_client = None
     client = TestClient(server.app)
     resp = client.post("/chat", json={"message": "test message"})
     data = resp.json()
@@ -40,6 +41,7 @@ def test_fallback_without_api_key():
 
 def test_with_openai_client_stub():
     server.openai_client = DummyClient()
+    server.memory.openai_client = server.openai_client
     client = TestClient(server.app)
     resp = client.post("/chat", json={"message": "whatever"})
     data = resp.json()

--- a/tests/test_memory_summary.py
+++ b/tests/test_memory_summary.py
@@ -1,0 +1,31 @@
+import sys
+import types
+import json
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+# Stub vector_store to avoid network calls
+stub_vs = types.ModuleType("utils.vector_store")
+stub_vs.add_memory_entry = lambda *a, **k: None
+sys.modules["utils.vector_store"] = stub_vs
+
+from utils import journal  # noqa: E402
+
+
+def test_memory_writes_journal(tmp_path, monkeypatch):
+    monkeypatch.setattr(journal, "LOG_PATH", str(tmp_path / "journal.json"))
+    import importlib
+    import utils.memory as memory
+    importlib.reload(memory)
+    from utils.memory import ConversationMemory, get_recent_summaries
+
+    mem = ConversationMemory(openai_client=None, threshold=2)
+    mem.add_message("user", "hello")
+    mem.add_message("assistant", "hi")
+    summaries = get_recent_summaries()
+    assert summaries and "hello" in summaries[-1]
+    # ensure journal file was created
+    with open(journal.LOG_PATH, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    assert data[-1]["type"] == "memory_summary"

--- a/utils/memory.py
+++ b/utils/memory.py
@@ -1,0 +1,70 @@
+import os
+import json
+from typing import List, Dict, Optional
+
+from utils.journal import log_event, LOG_PATH as JOURNAL_PATH
+
+try:
+    from utils import vector_store
+except Exception:  # pragma: no cover - optional dependency
+    vector_store = None  # type: ignore
+
+
+class ConversationMemory:
+    """Collects messages and periodically summarizes them.
+
+    Summaries are stored in ``data/journal.json`` via ``log_event`` and, when
+    possible, added to the vector store. Summarization uses an OpenAI client if
+    provided; otherwise the raw text is stored.
+    """
+
+    def __init__(self, openai_client: Optional[object] = None, threshold: int = 20):
+        self.openai_client = openai_client
+        self.threshold = threshold
+        self.buffer: List[Dict[str, str]] = []
+
+    def add_message(self, role: str, content: str) -> None:
+        """Add a message to the buffer and summarize if threshold is reached."""
+        self.buffer.append({"role": role, "content": content})
+        if len(self.buffer) >= self.threshold:
+            self.summarize()
+
+    def summarize(self) -> str:
+        """Summarize buffered messages and persist the result."""
+        if not self.buffer:
+            return ""
+        text = "\n".join(f"{m['role']}: {m['content']}" for m in self.buffer)
+        summary = text
+        if self.openai_client:
+            try:
+                resp = self.openai_client.chat.completions.create(
+                    model="gpt-4.1",
+                    messages=[
+                        {"role": "system", "content": "Summarize the conversation in under 100 words."},
+                        {"role": "user", "content": text},
+                    ],
+                    max_tokens=150,
+                )
+                summary = resp.choices[0].message.content.strip()
+            except Exception:
+                summary = text
+        log_event({"type": "memory_summary", "summary": summary})
+        if vector_store and self.openai_client:
+            try:
+                api_key = getattr(self.openai_client, "api_key", os.getenv("OPENAI_API_KEY", ""))
+                vector_store.add_memory_entry(summary, api_key, {"type": "summary"})
+            except Exception:
+                pass
+        self.buffer.clear()
+        return summary
+
+
+def get_recent_summaries(limit: int = 5) -> List[str]:
+    """Return the most recent stored summaries from ``data/journal.json``."""
+    try:
+        with open(JOURNAL_PATH, "r", encoding="utf-8") as f:
+            log = json.load(f)
+    except Exception:
+        return []
+    summaries = [e.get("summary", "") for e in log if e.get("type") == "memory_summary"]
+    return summaries[-limit:]


### PR DESCRIPTION
## Summary
- Add `ConversationMemory` utility to condense conversation snippets and store them in the journal and vector store.
- Pull recent memory summaries into chat sessions so the server can feed them into the model as system context.
- Document and test the new memory mechanism.

## Testing
- `python -m py_compile utils/memory.py webface/server.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68939f99893c8329ac52e8ce6fd7c5f4