### PR TITLE
Use chunked reads when hashing files

### DIFF
--- a/utils/config.py
+++ b/utils/config.py
@@ -35,8 +35,11 @@ def _save_snapshot(snapshot):
 
 def _file_hash(path):
     try:
+        hash_md5 = hashlib.md5()
         with open(path, "r", encoding="utf-8") as f:
-            return hashlib.md5(f.read().encode("utf-8")).hexdigest()
+            for chunk in iter(lambda: f.read(8192), ""):
+                hash_md5.update(chunk.encode("utf-8"))
+        return hash_md5.hexdigest()
     except Exception:
         return ""
 


### PR DESCRIPTION
## Summary
- Stream file content in `_file_hash` to compute MD5 hashes without loading whole file into memory

## Testing
- `flake8 .` *(fails: command not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a18f29b68c8329a61d76e6f57d3861