### PR TITLE
Refactor text extraction functions to use list joins

### DIFF
--- a/utils/file_handling.py
+++ b/utils/file_handling.py
@@ -9,12 +9,12 @@ def extract_text_from_pdf(path):
     """Extract text from PDF files."""
     try:
         reader = PdfReader(path)
-        text = ""
+        parts = []
         for page in reader.pages:
             page_text = page.extract_text()
             if page_text:
-                text += page_text + "\n\n"
-        text = text.strip()
+                parts.append(page_text)
+        text = "\n\n".join(parts).strip()
         if text:
             # Clean up text - remove excessive newlines and spaces
             text = re.sub(r'\n{3,}', '\n\n', text)
@@ -136,16 +136,16 @@ def extract_text_from_csv(path):
         with open(path, 'r', encoding='utf-8', errors='ignore') as f:
             reader = csv.reader(f)
             rows = list(reader)
-            
+
             # Format as a table
-            text = ""
+            parts = []
             for row in rows[:100]:  # Limit to first 100 rows
-                text += " | ".join(row) + "\n"
-                
+                parts.append(" | ".join(row))
+
             if len(rows) > 100:
-                text += "\n[Trimmed: only showing first 100 rows]"
-                
-            return text
+                parts.append("[Trimmed: only showing first 100 rows]")
+
+            return "\n".join(parts)
     except Exception as e:
         return f"[CSV reading error ({os.path.basename(path)}): {e}. Try converting to .txt for better resonance.]"
 


### PR DESCRIPTION
## Summary
- Avoid repeated string concatenation in PDF text extraction by collecting pages in a list and joining at the end
- Use list-based accumulation for CSV rows before joining into final text

## Testing
- `flake8 utils/file_handling.py` *(fails: F401, E302, E501, W293, F821, etc.)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a18f52e90c8329a68b698a70e39423