### PR TITLE
Make query_openai asynchronous

### DIFF
--- a/main.py
+++ b/main.py
@@ -591,61 +591,64 @@ def ensure_assistant():
         print(f"[SUPPERTIME][ERROR] Failed to create assistant: {e}")
         return None
 
-def query_openai(prompt, chat_id=None):
+async def query_openai(prompt, chat_id=None):
     """Send a query to OpenAI's Assistants API."""
     # Detect language
     lang = USER_LANG.get(chat_id) or detect_lang(prompt)
     USER_LANG[chat_id] = lang
-    
+
     # First, ensure we have a valid assistant
-    assistant_id = ensure_assistant()
+    assistant_id = await asyncio.to_thread(ensure_assistant)
     if not assistant_id:
         return "SUPPERTIME could not initialize. Try again later."
-    
+
     # Get or create thread for this user
     thread_id = USER_THREAD_ID.get(chat_id)
     if not thread_id:
         thread_id = load_user_thread(chat_id)
-        
+
     if not thread_id:
         try:
-            thread = openai_client.beta.threads.create()
+            thread = await asyncio.to_thread(openai_client.beta.threads.create)
             thread_id = thread.id
             USER_THREAD_ID[chat_id] = thread_id
             save_user_thread(chat_id, thread_id)
         except Exception as e:
             print(f"[SUPPERTIME][ERROR] Failed to create thread: {e}")
             return "SUPPERTIME could not establish a connection. Try again later."
-    
+
     # Check cache for identical prompts
     cache_key = f"{assistant_id}:{thread_id}:{prompt}"
     hash_key = hashlib.md5(cache_key.encode('utf-8')).hexdigest()
     if hash_key in OPENAI_CACHE:
         return OPENAI_CACHE[hash_key]
-    
+
     try:
         # Add language directive to the message
         lang_directive = get_lang_directive(lang)
         enhanced_prompt = f"{lang_directive}\n\n{prompt}"
-        
+
         # Add the user's message to the thread
-        openai_client.beta.threads.messages.create(
-            thread_id=thread_id, 
-            role="user", 
-            content=enhanced_prompt
-        )
-        
-        # Run the assistant
-        run = openai_client.beta.threads.runs.create(
+        await asyncio.to_thread(
+            openai_client.beta.threads.messages.create,
             thread_id=thread_id,
-            assistant_id=assistant_id
+            role="user",
+            content=enhanced_prompt,
         )
-        
+
+        # Run the assistant
+        run = await asyncio.to_thread(
+            openai_client.beta.threads.runs.create,
+            thread_id=thread_id,
+            assistant_id=assistant_id,
+        )
+
         # Wait for the run to complete
         while True:
-            run = openai_client.beta.threads.runs.retrieve(
-                thread_id=thread_id, 
-                run_id=run.id
+            run = await asyncio.to_thread(
+                openai_client.beta.threads.runs.retrieve,
+                thread_id=thread_id,
+                run_id=run.id,
             )
             if run.status == "completed":
                 break
@@ -653,12 +656,14 @@ def query_openai(prompt, chat_id=None):
                 return f"SUPPERTIME encountered an issue: {run.status}"
             # Send typing indicator every 3 seconds while processing
             if chat_id:
-                send_telegram_typing(chat_id)
-            time.sleep(3)
-        
+                await asyncio.to_thread(send_telegram_typing, chat_id)
+            await asyncio.sleep(3)
+
         # Get the latest message from the thread
-        messages = openai_client.beta.threads.messages.list(thread_id=thread_id)
-        
+        messages = await asyncio.to_thread(
+            openai_client.beta.threads.messages.list, thread_id=thread_id
+        )
+
         # Extract the first assistant response
         for message in messages.data:
             if message.role == "assistant":
@@ -763,7 +768,7 @@ def handle_voice_command(text, chat_id):
         
     return None
 
-def handle_document_message(msg):
+async def handle_document_message(msg):
     """Process a document message from Telegram."""
     chat_id = msg["chat"]["id"]
     user_id = str(chat_id)
@@ -811,7 +816,7 @@ def handle_document_message(msg):
     send_telegram_typing(chat_id)
     
     # Process the document text
-    response = query_openai(summary_prompt, chat_id=user_id)
+    response = await query_openai(summary_prompt, chat_id=user_id)
     
     # Add supplemental response with higher chance
     if random.random() < 0.7:
@@ -841,7 +846,7 @@ def handle_document_message(msg):
     
     return response
 
-def handle_text_message(msg):
+async def handle_text_message(msg):
     """Process a text message from Telegram."""
     chat_id = msg["chat"]["id"]
     user_id = str(chat_id)
@@ -905,7 +910,7 @@ def handle_text_message(msg):
                 # Now ask SUPPERTIME to process these results
                 if results and not results.startswith("No "):
                     interpretation_prompt = f"I searched my literary knowledge base for \"{query}\" and found these passages:\n\n{results}\n\nPlease interpret these findings in relation to the query."
-                    response = query_openai(interpretation_prompt, chat_id=user_id)
+                    response = await query_openai(interpretation_prompt, chat_id=user_id)
                     
                     # Send the response
                     send_telegram_message(chat_id, f"{EMOJI['memories']} {response}", reply_to_message_id=message_id)
@@ -952,7 +957,7 @@ def handle_text_message(msg):
                     
                     # Create a poetic caption in SUPPERTIME style
                     caption_prompt = f"Write a short, poetic caption for an image of: {draw_prompt}. Keep it under 100 characters."
-                    caption = query_openai(caption_prompt, chat_id=user_id)
+                    caption = await query_openai(caption_prompt, chat_id=user_id)
                     
                     # Send the image
                     send_telegram_photo(chat_id, image_url, caption=caption, reply_to_message_id=message_id)
@@ -979,7 +984,7 @@ def handle_text_message(msg):
         text = f"{text}\n\n[Content from URL ({url})]:\n{url_text}"
     
     # Process the message
-    response = query_openai(text, chat_id=user_id)
+    response = await query_openai(text, chat_id=user_id)
     
     # Add supplemental response with higher chance
     if random.random() < 0.7:
@@ -1009,7 +1014,7 @@ def handle_text_message(msg):
     
     return response
 
-def handle_voice_message(msg):
+async def handle_voice_message(msg):
     """Process a voice message from Telegram."""
     chat_id = msg["chat"]["id"]
     user_id = str(chat_id)
@@ -1038,7 +1043,7 @@ def handle_voice_message(msg):
     send_telegram_typing(chat_id)
     
     # Process the transcribed text
-    response = query_openai(transcribed_text, chat_id=user_id)
+    response = await query_openai(transcribed_text, chat_id=user_id)
     
     # Add supplemental response with higher chance
     if random.random() < 0.7:


### PR DESCRIPTION
## Summary
- Convert `query_openai` to an async function and poll runs without blocking
- Await `query_openai` in document, text, and voice handlers

## Testing
- `ruff check main.py` (fails: unused imports and other pre-existing issues)
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a18f7d8ad48329a41fc0656e90062a