### PR TITLE
Add unit tests for vector store, config, journal, and memory cleanup

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,56 @@
+import sys
+import types
+import importlib
+import json
+import hashlib
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+def test_file_hash(monkeypatch, tmp_path):
+    stub_vs = types.ModuleType("utils.vector_store")
+    stub_vs.vectorize_file = lambda *a, **k: None
+    stub_vs.semantic_search_in_file = lambda *a, **k: []
+    monkeypatch.setitem(sys.modules, "utils.vector_store", stub_vs)
+    import utils.config as config
+    importlib.reload(config)
+
+    file_path = tmp_path / "x.txt"
+    file_path.write_text("hello", encoding="utf-8")
+    expected = hashlib.md5(b"hello").hexdigest()
+    assert config._file_hash(str(file_path)) == expected
+    assert config._file_hash(str(tmp_path / "missing.txt")) == ""
+
+
+def test_vectorize_lit_files_workflow(monkeypatch, tmp_path):
+    calls = []
+    stub_vs = types.ModuleType("utils.vector_store")
+
+    def fake_vectorize_file(path, api_key):
+        calls.append(path)
+
+    stub_vs.vectorize_file = fake_vectorize_file
+    stub_vs.semantic_search_in_file = lambda *a, **k: []
+    monkeypatch.setitem(sys.modules, "utils.vector_store", stub_vs)
+    import utils.config as config
+    importlib.reload(config)
+
+    lit_dir = tmp_path / "lit"
+    lit_dir.mkdir()
+    file_path = lit_dir / "file.txt"
+    file_path.write_text("content", encoding="utf-8")
+
+    monkeypatch.setattr(config, "LIT_DIR", str(lit_dir))
+    monkeypatch.setattr(config, "SNAPSHOT_PATH", str(tmp_path / "snapshot.json"))
+
+    result = config.vectorize_lit_files()
+    assert result == "Indexed 1 files."
+    assert calls == [str(file_path)]
+
+    result2 = config.vectorize_lit_files()
+    assert result2 == "No new literary files to index."
+
+    with open(config.SNAPSHOT_PATH, "r", encoding="utf-8") as f:
+        snapshot = json.load(f)
+    assert snapshot[str(file_path)] == config._file_hash(str(file_path))

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -1,0 +1,25 @@
+import sys
+import json
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from utils import journal
+
+
+def test_log_event_appends(monkeypatch, tmp_path):
+    monkeypatch.setattr(journal, "LOG_PATH", str(tmp_path / "journal.json"))
+    journal.log_event({"type": "a"})
+    journal.log_event({"type": "b"})
+    with open(journal.LOG_PATH, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    assert data[0]["type"] == "a"
+    assert data[1]["type"] == "b"
+
+
+def test_wilderness_log_appends(monkeypatch, tmp_path):
+    monkeypatch.setattr(journal, "WILDERNESS_PATH", str(tmp_path / "wild.md"))
+    journal.wilderness_log("first")
+    journal.wilderness_log("second")
+    with open(journal.WILDERNESS_PATH, "r", encoding="utf-8") as f:
+        text = f.read()
+    assert text == "first\n\nsecond\n\n"

--- a/tests/test_main_memory_cleanup.py
+++ b/tests/test_main_memory_cleanup.py
@@ -1,0 +1,63 @@
+import sys
+import types
+import importlib
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+def test_log_history_cleanup(monkeypatch):
+    openai_stub = types.ModuleType("openai")
+
+    class DummyOpenAI:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    openai_stub.OpenAI = DummyOpenAI
+    monkeypatch.setitem(sys.modules, "openai", openai_stub)
+
+    pinecone_stub = types.ModuleType("pinecone")
+
+    class DummyPinecone:
+        def __init__(self, *a, **k):
+            pass
+
+        def list_indexes(self):
+            return []
+
+        def create_index(self, *a, **k):
+            pass
+
+        def Index(self, name):
+            class I:
+                def upsert(self, *a, **k):
+                    pass
+
+                def query(self, *a, **k):
+                    return {"matches": []}
+
+                def fetch(self, ids):
+                    return {}
+
+            return I()
+
+    pinecone_stub.Pinecone = DummyPinecone
+    pinecone_stub.ServerlessSpec = object
+    monkeypatch.setitem(sys.modules, "pinecone", pinecone_stub)
+
+    vs_stub = types.ModuleType("utils.vector_store")
+    vs_stub.vectorize_file = lambda *a, **k: None
+    vs_stub.semantic_search_in_file = lambda *a, **k: []
+    vs_stub.add_memory_entry = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, "utils.vector_store", vs_stub)
+
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    import main
+    importlib.reload(main)
+
+    for i in range(25):
+        main.log_history("user", f"msg{i}")
+
+    history = main.CHAT_HISTORY["user"]
+    assert len(history) == 20
+    assert history[0] == "msg5"

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -1,0 +1,98 @@
+import sys
+import types
+import importlib
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+@pytest.fixture
+def vector_store(monkeypatch):
+    sys.modules.pop("utils.vector_store", None)
+    monkeypatch.setenv("PINECONE_API_KEY", "test")
+    monkeypatch.setenv("PINECONE_INDEX", "test-index")
+
+    pinecone_stub = types.ModuleType("pinecone")
+
+    class DummyIndex:
+        def __init__(self):
+            self.upserts = []
+
+        def upsert(self, vectors):
+            self.upserts.extend(vectors)
+
+        def query(self, vector, top_k, include_metadata, filter):
+            return {"matches": [{"metadata": {"chunk": 0}}, {"metadata": {"chunk": 1}}]}
+
+        def fetch(self, ids):
+            return {}
+
+    class DummyPinecone:
+        def __init__(self, api_key=None):
+            self.index = DummyIndex()
+
+        def list_indexes(self):
+            return []
+
+        def create_index(self, *args, **kwargs):
+            pass
+
+        def Index(self, name):
+            return self.index
+
+    pinecone_stub.Pinecone = DummyPinecone
+
+    class DummyServerlessSpec:
+        def __init__(self, *a, **k):
+            pass
+
+    pinecone_stub.ServerlessSpec = DummyServerlessSpec
+    monkeypatch.setitem(sys.modules, "pinecone", pinecone_stub)
+
+    openai_stub = types.ModuleType("openai")
+    openai_stub.embeddings = types.SimpleNamespace(
+        create=lambda *a, **k: types.SimpleNamespace(data=[types.SimpleNamespace(embedding=[0.0])])
+    )
+    monkeypatch.setitem(sys.modules, "openai", openai_stub)
+
+    import utils.vector_store as vs
+    importlib.reload(vs)
+    return vs
+
+
+def test_chunk_text(vector_store):
+    chunks = vector_store.chunk_text("abcdefghij", chunk_size=5, overlap=2)
+    assert chunks[0] == "abcde"
+    assert chunks[1] == "defgh"
+    assert chunks[2] == "ghij"
+    assert chunks[3] == "j"
+
+
+def test_vectorize_and_search(monkeypatch, tmp_path, vector_store):
+    monkeypatch.setattr(
+        vector_store,
+        "chunk_text",
+        lambda text, chunk_size=900, overlap=120: ["alpha", "beta"],
+    )
+
+    calls = []
+
+    def fake_safe_embed(text, api_key):
+        calls.append(text)
+        return [0.1]
+
+    monkeypatch.setattr(vector_store, "safe_embed", fake_safe_embed)
+    index = vector_store.index
+
+    file_path = tmp_path / "sample.txt"
+    file_path.write_text("alpha beta", encoding="utf-8")
+
+    ids = vector_store.vectorize_file(str(file_path), "key")
+    assert ids == [f"{file_path}:{i}" for i in range(2)]
+    assert len(index.upserts) == 2
+
+    chunks = vector_store.semantic_search_in_file(str(file_path), "query", "key", top_k=2)
+    assert chunks == ["alpha", "beta"]
+    assert calls == ["alpha", "beta", "query"]


### PR DESCRIPTION
## Summary
- add tests for chunking and search in `utils.vector_store`
- cover hashing and vectorization workflow in `utils.config`
- test append-based logging in `utils.journal`
- verify chat history cleanup logic in `main.log_history`

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a190310c408329b7a167298c35cf52