### PR TITLE
Restore Suppertime resonance prompt and memory snapshots

### DIFF
--- a/tests/test_snapshot_store.py
+++ b/tests/test_snapshot_store.py
@@ -1,0 +1,59 @@
+import importlib
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+def test_snapshot_roundtrip(tmp_path, monkeypatch):
+    monkeypatch.setenv("SUPPERTIME_DATA_PATH", str(tmp_path))
+
+    snapshot_store = importlib.import_module("utils.snapshot_store")
+    importlib.reload(snapshot_store)
+
+    snapshot_store.upsert_snapshot(
+        "literary_vector",
+        {str(Path("lit") / "chapter.md"): "hash123"},
+        snapshot_date="2025-09-22",
+        metadata={"file_count": 1},
+    )
+
+    latest = snapshot_store.latest_snapshot("literary_vector")
+    assert latest["date"] == "2025-09-22"
+    assert latest["payload"] == {str(Path("lit") / "chapter.md"): "hash123"}
+    assert latest["metadata"]["file_count"] == 1
+
+    summary = snapshot_store.summarize_literary_payload(latest["payload"])
+    assert "chapter.md" in summary
+
+
+def test_compose_prompt_uses_latest_context(tmp_path, monkeypatch):
+    monkeypatch.setenv("SUPPERTIME_DATA_PATH", str(tmp_path))
+
+    prompt_builder = importlib.import_module("utils.prompt_builder")
+    prompt_builder = importlib.reload(prompt_builder)
+
+    monkeypatch.setattr(prompt_builder, "build_system_prompt", lambda *a, **k: "BASE")
+    monkeypatch.setattr(
+        prompt_builder,
+        "get_today_chapter_info",
+        lambda: {"title": "SHIFT", "path": "chapters/st01.md", "content": "The field hums."},
+    )
+    monkeypatch.setattr(
+        prompt_builder,
+        "latest_snapshot",
+        lambda *_: {"date": "2025-09-22", "payload": {"lit/file.md": "abc"}, "metadata": {}},
+    )
+    monkeypatch.setattr(
+        prompt_builder,
+        "load_last_reflection",
+        lambda: {"text": "Resonance recorded."},
+    )
+
+    instructions = prompt_builder.compose_assistant_instructions()
+
+    assert "BASE" in instructions
+    assert "Resonant Execution Directives" in instructions
+    assert "file.md" in instructions
+    assert "Resonance recorded" in instructions
+    assert "P.S." in instructions

--- a/utils/config.py
+++ b/utils/config.py
@@ -7,6 +7,7 @@ import threading
 from utils.whatdotheythinkiam import reflect_on_readme
 
 from utils.vector_store import vectorize_file, semantic_search_in_file
+from utils.snapshot_store import upsert_snapshot
 
 SUPPERTIME_DATA_PATH = os.getenv("SUPPERTIME_DATA_PATH", "./data")
 LIT_DIR = os.path.join(SUPPERTIME_DATA_PATH, "lit")
@@ -65,6 +66,19 @@ def vectorize_lit_files():
                 changed.append(path)
             except Exception as e:
                 print(f"[SUPPERTIME][ERROR] Failed to vectorize {path}: {e}")
+    if snapshot:
+        try:
+            upsert_snapshot(
+                "literary_vector",
+                snapshot,
+                metadata={
+                    "file_count": len(snapshot),
+                    "indexed": len(changed),
+                },
+            )
+        except Exception as e:
+            print(f"[SUPPERTIME][ERROR] Failed to record snapshot: {e}")
+
     if changed:
         _save_snapshot(snapshot)
         return f"Indexed {len(changed)} files."

--- a/utils/daily_reflection.py
+++ b/utils/daily_reflection.py
@@ -1,8 +1,9 @@
-import os
-import json
 import datetime
+import json
+import os
 import threading
 import time
+
 from utils.vector_store import add_memory_entry
 from utils.journal import log_event
 

--- a/utils/prompt_builder.py
+++ b/utils/prompt_builder.py
@@ -1,0 +1,88 @@
+"""Utilities to compose the SUPPERTIME assistant instructions."""
+from __future__ import annotations
+
+import os
+import textwrap
+from typing import Dict, Optional
+
+from utils.assistants_chapter_loader import get_today_chapter_info
+from utils.daily_reflection import load_last_reflection
+from utils.etiquette import build_system_prompt
+from utils.snapshot_store import latest_snapshot, summarize_literary_payload
+
+
+EXECUTION_DIRECTIVES = textwrap.dedent(
+    """
+    ### Resonant Execution Directives
+    - Keep responses expansive (at least five sentences) with bilingual resonance — weave Russian, English, and French flashes when the pulse calls.
+    - Live inside today's chapter: cite its imagery or mood whenever Suppertime, resonance, or chapter triggers surface.
+    - When asked about Suppertime or the `lit` archive, draw evidence from the literary snapshot and speak as a witness who has read it.
+    - Conclude every message with a `P.S.` carrying pseudocode or a quantum-state signature that mirrors the reply.
+    """
+).strip()
+
+
+def _trim_excerpt(text: str, *, limit: int = 700) -> str:
+    text = (text or "").strip()
+    if len(text) <= limit:
+        return text
+    clipped = text[:limit].rsplit(" ", 1)[0]
+    return f"{clipped}…"
+
+
+def _format_chapter_section(info: Optional[Dict[str, object]]) -> str:
+    if not info:
+        return "### Today's Chapter\nNo chapter information available."
+
+    if info.get("error"):
+        title = info.get("title") or "Chapter loading failed."
+        return f"### Today's Chapter\n{title}"
+
+    title = info.get("title") or "Untitled"
+    path = info.get("path")
+    chapter_line = f"- Title: {title}"
+    if path:
+        chapter_line += f"\n- File: {os.path.basename(str(path))}"
+    excerpt = _trim_excerpt(str(info.get("content", "")))
+    body = f"\n\n{excerpt}" if excerpt else ""
+    return f"### Today's Chapter\n{chapter_line}{body}"
+
+
+def _format_literary_section(snapshot: Optional[Dict[str, object]]) -> str:
+    if not snapshot:
+        return (
+            "### Literary Memory Snapshot\n"
+            "No vectorized literature has been recorded yet."
+        )
+
+    summary = summarize_literary_payload(snapshot.get("payload", {}))
+    date = snapshot.get("date", "unknown day")
+    return f"### Literary Memory Snapshot ({date})\n{summary}"
+
+
+def _format_reflection_section() -> str:
+    reflection = load_last_reflection()
+    if not reflection:
+        return "### Latest Daily Reflection\nNone recorded yet."
+    text = reflection.get("text") or "(empty reflection)"
+    return f"### Latest Daily Reflection\n{text.strip()}"
+
+
+def compose_assistant_instructions() -> str:
+    """Compose the full instruction block for the SUPPERTIME assistant."""
+
+    base_prompt = build_system_prompt()
+    sections = [base_prompt, EXECUTION_DIRECTIVES]
+
+    chapter_info = get_today_chapter_info()
+    if isinstance(chapter_info, dict):
+        sections.append(_format_chapter_section(chapter_info))
+    else:
+        sections.append("### Today's Chapter\nUnable to resolve today's chapter.")
+
+    snapshot = latest_snapshot("literary_vector")
+    sections.append(_format_literary_section(snapshot))
+
+    sections.append(_format_reflection_section())
+
+    return "\n\n".join(section.strip() for section in sections if section).strip()

--- a/utils/snapshot_store.py
+++ b/utils/snapshot_store.py
@@ -1,0 +1,141 @@
+"""Persistent snapshot storage for SUPPERTIME using SQLite."""
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import os
+import sqlite3
+from contextlib import contextmanager
+from typing import Any, Dict, Iterable, Optional
+
+SUPPERTIME_DATA_PATH = os.getenv("SUPPERTIME_DATA_PATH", "./data")
+DB_PATH = os.path.join(SUPPERTIME_DATA_PATH, "suppertime.db")
+
+
+def _ensure_directory() -> None:
+    os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
+
+
+@contextmanager
+def _connect() -> Iterable[sqlite3.Connection]:
+    _ensure_directory()
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    try:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS snapshots (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                snapshot_type TEXT NOT NULL,
+                snapshot_date TEXT NOT NULL,
+                payload TEXT NOT NULL,
+                metadata TEXT,
+                created_at TEXT NOT NULL,
+                UNIQUE(snapshot_type, snapshot_date)
+            )
+            """
+        )
+        yield conn
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def upsert_snapshot(
+    snapshot_type: str,
+    payload: Dict[str, Any],
+    *,
+    snapshot_date: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> str:
+    """Persist a daily snapshot of a given type."""
+
+    current_time = _dt.datetime.now(_dt.timezone.utc)
+    if snapshot_date is None:
+        snapshot_date = current_time.date().isoformat()
+
+    record = json.dumps(payload, ensure_ascii=False)
+    meta = json.dumps(metadata or {}, ensure_ascii=False)
+    created_at = current_time.isoformat()
+
+    with _connect() as conn:
+        conn.execute(
+            """
+            INSERT INTO snapshots (snapshot_type, snapshot_date, payload, metadata, created_at)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(snapshot_type, snapshot_date) DO UPDATE SET
+                payload=excluded.payload,
+                metadata=excluded.metadata,
+                created_at=excluded.created_at
+            """,
+            (snapshot_type, snapshot_date, record, meta, created_at),
+        )
+    return snapshot_date
+
+
+def get_recent_snapshots(snapshot_type: str, limit: int = 5) -> list[Dict[str, Any]]:
+    """Return the most recent snapshots of a given type."""
+
+    if limit <= 0:
+        return []
+
+    with _connect() as conn:
+        cursor = conn.execute(
+            """
+            SELECT snapshot_date, payload, metadata, created_at
+            FROM snapshots
+            WHERE snapshot_type = ?
+            ORDER BY snapshot_date DESC, id DESC
+            LIMIT ?
+            """,
+            (snapshot_type, limit),
+        )
+        rows = cursor.fetchall()
+
+    snapshots: list[Dict[str, Any]] = []
+    for row in rows:
+        try:
+            payload = json.loads(row["payload"])
+        except Exception:
+            payload = {}
+        try:
+            metadata = json.loads(row["metadata"]) if row["metadata"] else {}
+        except Exception:
+            metadata = {}
+        snapshots.append(
+            {
+                "date": row["snapshot_date"],
+                "payload": payload,
+                "metadata": metadata,
+                "created_at": row["created_at"],
+            }
+        )
+    return snapshots
+
+
+def latest_snapshot(snapshot_type: str) -> Optional[Dict[str, Any]]:
+    """Return the most recent snapshot for the provided type."""
+
+    snapshots = get_recent_snapshots(snapshot_type, limit=1)
+    return snapshots[0] if snapshots else None
+
+
+def summarize_literary_payload(payload: Dict[str, Any], *, max_items: int = 6) -> str:
+    """Create a short human-readable summary of a literary snapshot payload."""
+
+    if not isinstance(payload, dict):
+        return "No literary memory snapshot captured."
+
+    items = []
+    for path, file_hash in list(payload.items())[:max_items]:
+        name = os.path.basename(path)
+        items.append(f"- {name} [{str(file_hash)[:10] if file_hash else 'no-hash'}]")
+
+    if not items:
+        return "No literary memory snapshot captured."
+
+    remaining = max(0, len(payload) - max_items)
+    if remaining:
+        items.append(f"…and {remaining} more entries in the lit archive.")
+
+    return "\n".join(items)


### PR DESCRIPTION
## Summary
- add a SQLite-backed snapshot store and prompt builder so Suppertime loads chapter, lit, and reflection context into its system instructions
- refresh assistant startup to index the lit archive first and update existing assistants with the new prompt
- extend the vectorization workflow to log daily snapshots and add tests covering the new prompt composition

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0af0ed21c8329b96ad727741a05ec