### PR TITLE
Fix ExpiringDict import regression

### DIFF
--- a/utils/expiring_dict.py
+++ b/utils/expiring_dict.py
@@ -71,3 +71,8 @@ class ExpiringCache:
 
     def __len__(self):
         return len(self.keys())
+
+
+class ExpiringDict(ExpiringCache):
+    """Backward-compatible alias for older imports."""
+    pass


### PR DESCRIPTION
## Summary
- add a backward-compatible `ExpiringDict` alias so existing imports continue to work

## Testing
- pytest *(fails: existing tests expect updated etiquette prompts and utils.behavior module which are outside the scope of this fix)*

------
https://chatgpt.com/codex/tasks/task_e_68d2d8c65a708329878b289e64d90567