### PR TITLE
Restore legacy load_today_chapter API for resonator

### DIFF
--- a/utils/assistants_chapter_loader.py
+++ b/utils/assistants_chapter_loader.py
@@ -155,6 +155,37 @@ def get_today_chapter_info() -> Dict[str, Any]:
     return info
 
 
+def load_today_chapter(return_path: bool = False) -> str:
+    """Compatibility wrapper that returns today's chapter content or path.
+
+    Historically, other modules imported :func:`load_today_chapter` directly
+    from this module. The rotation refactor introduced
+    :func:`get_today_chapter_info` without preserving the legacy API, which
+    caused import failures in production environments. This helper restores the
+    original interface while delegating to the richer chapter metadata loader.
+
+    Args:
+        return_path: When ``True``, return the resolved filesystem path instead
+            of the chapter contents. Errors are returned as human-readable
+            strings regardless of the flag so callers receive context.
+
+    Returns:
+        The chapter contents or path for today, or an error string if the
+        chapter could not be loaded.
+    """
+
+    info = get_today_chapter_info()
+
+    if info.get("error"):
+        # Preserve compatibility by returning the descriptive error message.
+        return info.get("title") or "[Resonator] Chapter unavailable."
+
+    if return_path:
+        return info.get("path") or ""
+
+    return info.get("content", "")
+
+
 def _notify_chapter_selection(title: str):
     if TELEGRAM_API_URL and (SUPPERTIME_CHAT_ID or SUPPERTIME_GROUP_ID):
         data = {"chat_id": SUPPERTIME_CHAT_ID or SUPPERTIME_GROUP_ID, "text": f"Today's chapter: {title}"}


### PR DESCRIPTION
## Summary
- reintroduce a `load_today_chapter` compatibility wrapper in `assistants_chapter_loader`
- delegate to the rotation metadata helper while preserving legacy error behaviour

## Testing
- `pytest` *(fails: tests/test_anti_politeness.py::test_system_prompt_contains_anti_politeness_directives, tests/test_anti_politeness.py::test_generate_response_prompts_are_direct, tests/test_howru.py::test_generate_checkin_without_client_uses_fallback_seeded, tests/test_main_memory_cleanup.py::test_log_history_cleanup)*

------
https://chatgpt.com/codex/tasks/task_e_68d2dc5f5bc0832992b9cdddbf1b0880