### PR TITLE
Fix expiring cache lookups and isolate namespaces

### DIFF
--- a/main.py
+++ b/main.py
@@ -77,13 +77,13 @@ STATE_DB_PATH = os.path.join(SUPPERTIME_DATA_PATH, "suppertime.db")
 # User settings
 STATE_TTL_SECONDS = int(os.getenv("STATE_TTL_SECONDS", 24 * 60 * 60))
 STATE_CLEANUP_INTERVAL = int(os.getenv("STATE_CLEANUP_INTERVAL", 60))
-USER_VOICE_MODE = ExpiringDict(STATE_TTL_SECONDS)  # Track which users have voice enabled
-USER_AUDIO_MODE = ExpiringDict(STATE_TTL_SECONDS)
-USER_LAST_MESSAGE = ExpiringDict(STATE_TTL_SECONDS)
-USER_LANG = ExpiringDict(STATE_TTL_SECONDS)
-CHAT_HISTORY = ExpiringDict(STATE_TTL_SECONDS)
-CONVERSATION_LOG = ExpiringDict(STATE_TTL_SECONDS)
-PENDING_DRAFT = ExpiringDict(STATE_TTL_SECONDS)
+USER_VOICE_MODE = ExpiringDict(STATE_TTL_SECONDS, namespace="USER_VOICE_MODE")  # Track which users have voice enabled
+USER_AUDIO_MODE = ExpiringDict(STATE_TTL_SECONDS, namespace="USER_AUDIO_MODE")
+USER_LAST_MESSAGE = ExpiringDict(STATE_TTL_SECONDS, namespace="USER_LAST_MESSAGE")
+USER_LANG = ExpiringDict(STATE_TTL_SECONDS, namespace="USER_LANG")
+CHAT_HISTORY = ExpiringDict(STATE_TTL_SECONDS, namespace="CHAT_HISTORY")
+CONVERSATION_LOG = ExpiringDict(STATE_TTL_SECONDS, namespace="CONVERSATION_LOG")
+PENDING_DRAFT = ExpiringDict(STATE_TTL_SECONDS, namespace="PENDING_DRAFT")
 MAX_HISTORY_MESSAGES = 7
 MAX_PROMPT_TOKENS = 8000
 
@@ -97,7 +97,7 @@ TELEGRAM_FILE_URL = f"https://api.telegram.org/file/bot{TELEGRAM_BOT_TOKEN}"
 
 # Thread storage
 THREAD_STORAGE_PATH = os.path.join(SUPPERTIME_DATA_PATH, "threads")
-USER_THREAD_ID = ExpiringDict(STATE_TTL_SECONDS)
+USER_THREAD_ID = ExpiringDict(STATE_TTL_SECONDS, namespace="USER_THREAD_ID")
 
 # Emoji constants
 EMOJI = {

--- a/utils/expiring_dict.py
+++ b/utils/expiring_dict.py
@@ -1,17 +1,56 @@
+import ast
+import base64
 import os
+import pickle
 import sqlite3
 import time
+from collections.abc import MutableMapping
 from typing import Optional, Any
 
 CACHE_DB = os.path.join(os.getenv("SUPPERTIME_DATA_PATH", "./data"), "expiring_cache.db")
 
 
-class ExpiringCache:
+SERIALIZATION_PREFIX = "b64:"
+
+
+def _serialize(value: Any) -> str:
+    """Serialize Python objects into a safe base64-encoded string."""
+    payload = pickle.dumps(value)
+    encoded = base64.b64encode(payload).decode("ascii")
+    return f"{SERIALIZATION_PREFIX}{encoded}"
+
+
+def _deserialize(value: Any) -> tuple[Any, bool]:
+    """Deserialize stored values and report whether they came from legacy format."""
+    if isinstance(value, str) and value.startswith(SERIALIZATION_PREFIX):
+        data = value[len(SERIALIZATION_PREFIX) :]
+        try:
+            payload = base64.b64decode(data.encode("ascii"))
+            return pickle.loads(payload), False
+        except Exception:
+            # If decoding fails, fall back to the stored string as legacy data
+            return value, True
+    if isinstance(value, str):
+        try:
+            return ast.literal_eval(value), True
+        except (ValueError, SyntaxError):
+            return value, True
+    return value, True
+
+
+class ExpiringCache(MutableMapping):
     """SQLite-based cache with TTL per key."""
 
-    def __init__(self, ttl_seconds: int = 3600, db_path: str = CACHE_DB):
+    def __init__(
+        self,
+        ttl_seconds: int = 3600,
+        db_path: str = CACHE_DB,
+        namespace: Optional[str] = None,
+    ):
         self.ttl = ttl_seconds
         self.db_path = db_path
+        self.namespace = namespace or self.__class__.__name__
+        self._prefix = f"{self.namespace}::"
         os.makedirs(os.path.dirname(self.db_path), exist_ok=True)
         self._init_db()
 
@@ -26,21 +65,32 @@ class ExpiringCache:
             """)
             conn.commit()
 
+    def _scoped_key(self, key: str) -> str:
+        return f"{self._prefix}{key}"
+
+    def _strip_prefix(self, stored_key: str) -> Optional[str]:
+        if not stored_key.startswith(self._prefix):
+            return None
+        return stored_key[len(self._prefix) :]
+
     def set(self, key: str, value: Any):
         ts = time.time()
+        encoded_value = _serialize(value)
+        scoped_key = self._scoped_key(str(key))
         with sqlite3.connect(self.db_path) as conn:
             conn.execute(
                 "INSERT OR REPLACE INTO expiring_cache (key, value, ts) VALUES (?, ?, ?)",
-                (key, str(value), ts)
+                (scoped_key, encoded_value, ts)
             )
             conn.commit()
 
-    def get(self, key: str) -> Optional[str]:
+    def _get_with_timestamp(self, key: str) -> Optional[tuple[Any, float, bool]]:
         now = time.time()
+        scoped_key = self._scoped_key(str(key))
         with sqlite3.connect(self.db_path) as conn:
             row = conn.execute(
                 "SELECT value, ts FROM expiring_cache WHERE key = ?",
-                (key,)
+                (scoped_key,)
             ).fetchone()
         if not row:
             return None
@@ -48,11 +98,22 @@ class ExpiringCache:
         if now - ts > self.ttl:
             self.delete(key)
             return None
+        decoded, legacy = _deserialize(value)
+        return decoded, ts, legacy
+
+    def get(self, key: str, default: Any = None) -> Any:
+        result = self._get_with_timestamp(key)
+        if result is None:
+            return default
+        value, _, legacy = result
+        if legacy:
+            self.set(key, value)
         return value
 
     def delete(self, key: str):
+        scoped_key = self._scoped_key(str(key))
         with sqlite3.connect(self.db_path) as conn:
-            conn.execute("DELETE FROM expiring_cache WHERE key = ?", (key,))
+            conn.execute("DELETE FROM expiring_cache WHERE key = ?", (scoped_key,))
             conn.commit()
 
     def cleanup(self):
@@ -66,11 +127,49 @@ class ExpiringCache:
         """Return non-expired keys."""
         now = time.time()
         with sqlite3.connect(self.db_path) as conn:
-            rows = conn.execute("SELECT key, ts FROM expiring_cache").fetchall()
-        return [k for k, ts in rows if now - ts <= self.ttl]
+            rows = conn.execute(
+                "SELECT key, ts FROM expiring_cache WHERE key LIKE ?",
+                (f"{self._prefix}%",),
+            ).fetchall()
+        result = []
+        for stored_key, ts in rows:
+            if now - ts > self.ttl:
+                continue
+            user_key = self._strip_prefix(stored_key)
+            if user_key is not None:
+                result.append(user_key)
+        return result
 
     def __len__(self):
         return len(self.keys())
+
+    # MutableMapping interface
+    def __getitem__(self, key: str) -> Any:
+        result = self._get_with_timestamp(key)
+        if result is None:
+            raise KeyError(key)
+        value, _, legacy = result
+        if legacy:
+            self.set(key, value)
+        return value
+
+    def __setitem__(self, key: str, value: Any):
+        self.set(key, value)
+
+    def __delitem__(self, key: str):
+        if self._get_with_timestamp(key) is None:
+            raise KeyError(key)
+        self.delete(key)
+
+    def __iter__(self):
+        return iter(self.keys())
+
+    def __contains__(self, key: object) -> bool:
+        try:
+            lookup_key = str(key)
+        except Exception:
+            return False
+        return self._get_with_timestamp(lookup_key) is not None
 
 
 class ExpiringDict(ExpiringCache):


### PR DESCRIPTION
## Summary
- upgrade the SQLite-backed expiring cache to serialize real Python objects, expose a dict-like API, and accept defaults when reading
- add per-instance namespaces so independent ExpiringDict usages no longer clobber each other’s keys
- update cache instantiations in `main.py` to use the new namespaces

## Testing
- pytest *(fails: tests/test_anti_politeness.py::test_system_prompt_contains_anti_politeness_directives, tests/test_anti_politeness.py::test_generate_response_prompts_are_direct, tests/test_howru.py::test_generate_checkin_without_client_uses_fallback_seeded)*
- pytest tests/test_main_memory_cleanup.py::test_log_history_cleanup -q


------
https://chatgpt.com/codex/tasks/task_e_68d2ed7f57b48329845232286677c0cb